### PR TITLE
feat: show publications and innovations on profile

### DIFF
--- a/frontend_project_fund/app/lib/profile_api.js
+++ b/frontend_project_fund/app/lib/profile_api.js
@@ -14,6 +14,28 @@ export const profileAPI = {
     }
   },
 
+  // Fetch current user's publications
+  async getPublications() {
+    try {
+      const response = await apiClient.get('/publications');
+      return response.publications || response;
+    } catch (error) {
+      console.error('Error fetching publications:', error);
+      throw error;
+    }
+  },
+
+  // Fetch current user's innovations
+  async getInnovations() {
+    try {
+      const response = await apiClient.get('/innovations');
+      return response.innovations || response;
+    } catch (error) {
+      console.error('Error fetching innovations:', error);
+      throw error;
+    }
+  },
+
   // Change current user's password
   async changePassword(currentPassword, newPassword, confirmPassword) {
     try {

--- a/frontend_project_fund/app/teacher/components/profile/UserProfile.js
+++ b/frontend_project_fund/app/teacher/components/profile/UserProfile.js
@@ -1,16 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import {
-  User,
-  Mail,
-  Phone,
-  Building,
-  FileText,
   TrendingUp,
   DollarSign,
-  Clock,
-  Bell,
-  Settings,
-  Camera,
   Activity
 } from 'lucide-react';
 
@@ -46,6 +37,8 @@ const defaultTeacherData = {
 export default function ProfileContent({ onNavigate }) {
   const [teacherData, setTeacherData] = useState(defaultTeacherData);
   const [loading, setLoading] = useState(true);
+  const [publications, setPublications] = useState([]);
+  const [innovations, setInnovations] = useState([]);
 
   useEffect(() => {
     loadProfileData();
@@ -54,9 +47,11 @@ export default function ProfileContent({ onNavigate }) {
   const loadProfileData = async () => {
     try {
       setLoading(true);
-      const [profileRes, statsRes] = await Promise.all([
+      const [profileRes, statsRes, pubsRes, innovRes] = await Promise.all([
         profileAPI.getProfile(),
-        teacherAPI.getDashboardStats()
+        teacherAPI.getDashboardStats(),
+        profileAPI.getPublications(),
+        profileAPI.getInnovations()
       ]);
 
       const profile = profileRes || {};
@@ -99,6 +94,8 @@ export default function ProfileContent({ onNavigate }) {
           destination: 'applications'
         }))
       });
+      setPublications(pubsRes.publications || pubsRes || []);
+      setInnovations(innovRes.innovations || innovRes || []);
     } catch (error) {
       console.error('Error loading profile:', error);
     } finally {
@@ -118,228 +115,132 @@ export default function ProfileContent({ onNavigate }) {
   }
 
   return (
-    <div className="flex">
-      {/* Main Content Area */}
-      <div className="flex-1 pr-0 lg:pr-80">
-        {/* Welcome Banner */}
-        <div className="bg-gradient-to-r from-blue-500 to-purple-600 text-white p-6 rounded-lg mb-6 shadow-lg">
-          <h2 className="text-2xl font-bold mb-2">
-            สวัสดี, {teacherData.position}{teacherData.user_fname} {teacherData.user_lname}
-          </h2>
-          <p className="opacity-90">ยินดีต้อนรับเข้าสู่ระบบบริหารจัดการทุนวิจัย</p>
-        </div>
+    <div className="space-y-6">
+      {/* Budget Summary */}
+      <div className="bg-white rounded-lg shadow p-6">
+        <h3 className="text-lg font-semibold text-gray-900 mb-4">สรุปงบประมาณ</h3>
 
-        {/* Stats Cards Grid */}
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
-          <div className="bg-gradient-to-br from-blue-500 to-blue-600 text-white p-6 rounded-lg shadow-lg transform transition-transform hover:scale-105">
-            <div className="flex justify-between items-start">
-              <div>
-                <div className="text-3xl font-bold mb-1">{teacherData.stats.totalApplications}</div>
-                <div className="text-sm opacity-90">คำร้องทั้งหมดของฉัน</div>
-              </div>
-              <FileText size={32} className="opacity-30" />
+        <div className="space-y-4">
+          <div className="flex items-center justify-between p-4 bg-gray-50 rounded-lg">
+            <div className="flex items-center space-x-3">
+              <DollarSign size={20} className="text-gray-600" />
+              <span className="font-medium">งบประมาณทั้งหมด</span>
             </div>
+            <span className="text-xl font-bold">฿{teacherData.stats.totalBudgetReceived.toLocaleString()}</span>
           </div>
 
-          <div className="bg-gradient-to-br from-teal-500 to-teal-600 text-white p-6 rounded-lg shadow-lg transform transition-transform hover:scale-105">
-            <div className="flex justify-between items-start">
-              <div>
-                <div className="text-3xl font-bold mb-1">{teacherData.stats.approvedApplications}</div>
-                <div className="text-sm opacity-90">อนุมัติแล้ว</div>
-              </div>
-              <TrendingUp size={32} className="opacity-30" />
-            </div>
-          </div>
-
-          <div className="bg-gradient-to-br from-pink-500 to-purple-600 text-white p-6 rounded-lg shadow-lg transform transition-transform hover:scale-105">
-            <div className="flex justify-between items-start">
-              <div>
-                <div className="text-3xl font-bold mb-1">{teacherData.stats.pendingApplications}</div>
-                <div className="text-sm opacity-90">รอพิจารณา</div>
-              </div>
-              <Clock size={32} className="opacity-30" />
-            </div>
-          </div>
-
-          <div className="bg-gradient-to-br from-red-500 to-pink-500 text-white p-6 rounded-lg shadow-lg transform transition-transform hover:scale-105">
-            <div className="flex justify-between items-start">
-              <div>
-                <div className="text-3xl font-bold mb-1">฿{teacherData.stats.usedBudget.toLocaleString()}</div>
-                <div className="text-sm opacity-90">งบประมาณที่ใช้ไปปีนี้</div>
-              </div>
-              <DollarSign size={32} className="opacity-30" />
-            </div>
-          </div>
-        </div>
-
-        {/* Budget Summary */}
-        <div className="bg-white rounded-lg shadow p-6 mb-6">
-          <h3 className="text-lg font-semibold text-gray-900 mb-4">สรุปงบประมาณ</h3>
-
-          <div className="space-y-4">
-            <div className="flex items-center justify-between p-4 bg-gray-50 rounded-lg">
-              <div className="flex items-center space-x-3">
-                <DollarSign size={20} className="text-gray-600" />
-                <span className="font-medium">งบประมาณทั้งหมด</span>
-              </div>
-              <span className="text-xl font-bold">฿{teacherData.stats.totalBudgetReceived.toLocaleString()}</span>
-            </div>
-
-            <div className="flex items-center justify-between p-4 bg-blue-50 rounded-lg">
-              <div className="flex items-center space-x-3">
-                <TrendingUp size={20} className="text-blue-600" />
-                <span className="font-medium">ใช้ไปในปีนี้</span>
-                <span className="text-sm text-blue-600">
-                  {teacherData.stats.successRate}% ของทั้งหมด
-                </span>
-              </div>
-              <span className="text-xl font-bold text-blue-600">฿{teacherData.stats.usedBudget.toLocaleString()}</span>
-            </div>
-
-            <div className="flex items-center justify-between p-4 bg-green-50 rounded-lg">
-              <div className="flex items-center space-x-3">
-                <Activity size={20} className="text-green-600" />
-                <span className="font-medium">คงเหลือสำหรับปีนี้</span>
-                <span className="text-sm text-green-600">
-                  {teacherData.stats.remainingBudget && teacherData.stats.totalBudgetReceived
-                    ? ((teacherData.stats.remainingBudget / teacherData.stats.totalBudgetReceived) * 100).toFixed(1)
-                    : 0}% ของทั้งหมด
-                </span>
-              </div>
-              <span className="text-xl font-bold text-green-600">฿{teacherData.stats.remainingBudget.toLocaleString()}</span>
-            </div>
-          </div>
-
-          {/* Progress Bar */}
-          <div className="mt-6">
-            <div className="flex justify-between items-center mb-2">
-              <span className="text-sm font-medium text-gray-700">การใช้งบประมาณ</span>
-              <span className="text-sm font-bold text-gray-900">{teacherData.stats.successRate}%</span>
-            </div>
-            <div className="w-full bg-gray-200 rounded-full h-3 overflow-hidden">
-              <div className="flex h-full">
-                <div
-                  className="bg-blue-500 transition-all duration-500"
-                  style={{ width: `${teacherData.stats.successRate}%` }}
-                ></div>
-                <div
-                  className="bg-green-500 transition-all duration-500"
-                  style={{ width: `${teacherData.stats.totalBudgetReceived ? ((teacherData.stats.remainingBudget / teacherData.stats.totalBudgetReceived) * 100) : 0}%` }}
-                ></div>
-              </div>
-            </div>
-            <div className="flex justify-between mt-2">
-              <span className="text-xs text-blue-600">ใช้ไป: {teacherData.stats.successRate}%</span>
-              <span className="text-xs text-green-600">
-                คงเหลือ: {teacherData.stats.totalBudgetReceived ? ((teacherData.stats.remainingBudget / teacherData.stats.totalBudgetReceived) * 100).toFixed(1) : 0}%
+          <div className="flex items-center justify-between p-4 bg-blue-50 rounded-lg">
+            <div className="flex items-center space-x-3">
+              <TrendingUp size={20} className="text-blue-600" />
+              <span className="font-medium">ใช้ไปในปีนี้</span>
+              <span className="text-sm text-blue-600">
+                {teacherData.stats.successRate}% ของทั้งหมด
               </span>
             </div>
+            <span className="text-xl font-bold text-blue-600">฿{teacherData.stats.usedBudget.toLocaleString()}</span>
+          </div>
+
+          <div className="flex items-center justify-between p-4 bg-green-50 rounded-lg">
+            <div className="flex items-center space-x-3">
+              <Activity size={20} className="text-green-600" />
+              <span className="font-medium">คงเหลือสำหรับปีนี้</span>
+              <span className="text-sm text-green-600">
+                {teacherData.stats.remainingBudget && teacherData.stats.totalBudgetReceived
+                  ? ((teacherData.stats.remainingBudget / teacherData.stats.totalBudgetReceived) * 100).toFixed(1)
+                  : 0}% ของทั้งหมด
+              </span>
+            </div>
+            <span className="text-xl font-bold text-green-600">฿{teacherData.stats.remainingBudget.toLocaleString()}</span>
           </div>
         </div>
 
-        {/* Call to Action */}
-        <div className="bg-gradient-to-br from-blue-500 to-purple-600 text-white rounded-lg p-6 shadow-lg">
-          <div className="flex items-center space-x-2 mb-2">
-            <Activity size={24} />
-            <h3 className="text-lg font-semibold">สรุปการใช้งบประมาณ</h3>
+        {/* Progress Bar */}
+        <div className="mt-6">
+          <div className="flex justify-between items-center mb-2">
+            <span className="text-sm font-medium text-gray-700">การใช้งบประมาณ</span>
+            <span className="text-sm font-bold text-gray-900">{teacherData.stats.successRate}%</span>
           </div>
-          <p className="mb-4 opacity-90">
-            คุณได้ใช้งบประมาณไปแล้ว {teacherData.stats.successRate}% จากงบประมาณทั้งหมดที่ได้รับ
-          </p>
-          <button
-            onClick={() => onNavigate && onNavigate('applications')}
-            className="bg-white text-blue-600 px-4 py-2 rounded-lg font-medium hover:bg-gray-100 transition-colors"
-          >
-            ดูรายละเอียดเพิ่มเติม
-          </button>
+          <div className="w-full bg-gray-200 rounded-full h-3 overflow-hidden">
+            <div className="flex h-full">
+              <div
+                className="bg-blue-500 transition-all duration-500"
+                style={{ width: `${teacherData.stats.successRate}%` }}
+              ></div>
+              <div
+                className="bg-green-500 transition-all duration-500"
+                style={{ width: `${teacherData.stats.totalBudgetReceived ? ((teacherData.stats.remainingBudget / teacherData.stats.totalBudgetReceived) * 100) : 0}%` }}
+              ></div>
+            </div>
+          </div>
+          <div className="flex justify-between mt-2">
+            <span className="text-xs text-blue-600">ใช้ไป: {teacherData.stats.successRate}%</span>
+            <span className="text-xs text-green-600">
+              คงเหลือ: {teacherData.stats.totalBudgetReceived ? ((teacherData.stats.remainingBudget / teacherData.stats.totalBudgetReceived) * 100).toFixed(1) : 0}%
+            </span>
+          </div>
         </div>
       </div>
 
-      {/* Right Sidebar - Fixed Position */}
-      <div className="hidden lg:block fixed right-0 top-20 bottom-0 w-80 p-6 bg-white border-l border-gray-200 overflow-y-auto">
-        {/* Profile Card */}
-        <div className="text-center mb-6">
-          <div className="relative inline-block mb-4">
-            <div className="w-24 h-24 bg-gradient-to-br from-green-400 to-green-600 rounded-full flex items-center justify-center">
-              {teacherData.profileImage ? (
-                <img
-                  src={teacherData.profileImage}
-                  alt="Profile"
-                  className="w-full h-full rounded-full object-cover"
-                />
-              ) : (
-                <span className="text-white text-3xl font-bold">
-                  {teacherData.user_fname?.[0] || ''}
-                </span>
-              )}
-            </div>
-            <button className="absolute bottom-0 right-0 bg-blue-600 text-white p-2 rounded-full hover:bg-blue-700 transition-colors">
-              <Camera size={16} />
-            </button>
+      {/* Publications Table */}
+      <div className="bg-white rounded-lg shadow p-6">
+        <h3 className="text-lg font-semibold text-gray-900 mb-4">Publications</h3>
+        {publications.length === 0 ? (
+          <p className="text-sm text-gray-500">ไม่มีข้อมูลผลงานตีพิมพ์</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-2 text-left text-sm font-medium text-gray-700">Title</th>
+                  <th className="px-4 py-2 text-left text-sm font-medium text-gray-700">Year</th>
+                  <th className="px-4 py-2 text-left text-sm font-medium text-gray-700">Status</th>
+                  <th className="px-4 py-2 text-left text-sm font-medium text-gray-700">Actions</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200">
+                {publications.map((pub) => (
+                  <tr key={pub.id}>
+                    <td className="px-4 py-2 whitespace-nowrap">{pub.title}</td>
+                    <td className="px-4 py-2 whitespace-nowrap">{pub.publication_date ? new Date(pub.publication_date).getFullYear() : '-'}</td>
+                    <td className="px-4 py-2 whitespace-nowrap">-</td>
+                    <td className="px-4 py-2 whitespace-nowrap">-</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
           </div>
-          <h3 className="font-bold text-lg text-gray-900">{teacherData.user_fname} {teacherData.user_lname}</h3>
-          <p className="text-sm text-gray-600 mb-1">{teacherData.position}</p>
-          <p className="text-xs text-gray-500">{teacherData.department}</p>
+        )}
+      </div>
 
-          <div className="flex justify-center space-x-2 mt-4">
-            <button className="p-2 bg-gray-100 rounded-lg hover:bg-gray-200 transition-colors">
-              <Bell size={20} className="text-gray-600" />
-            </button>
-            <button className="p-2 bg-gray-100 rounded-lg hover:bg-gray-200 transition-colors">
-              <Mail size={20} className="text-gray-600" />
-            </button>
-            <button className="p-2 bg-gray-100 rounded-lg hover:bg-gray-200 transition-colors">
-              <Settings size={20} className="text-gray-600" />
-            </button>
+      {/* Innovations Table */}
+      <div className="bg-white rounded-lg shadow p-6">
+        <h3 className="text-lg font-semibold text-gray-900 mb-4">Innovations</h3>
+        {innovations.length === 0 ? (
+          <p className="text-sm text-gray-500">ไม่มีข้อมูลนวัตกรรม</p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-2 text-left text-sm font-medium text-gray-700">Title</th>
+                  <th className="px-4 py-2 text-left text-sm font-medium text-gray-700">Year</th>
+                  <th className="px-4 py-2 text-left text-sm font-medium text-gray-700">Status</th>
+                  <th className="px-4 py-2 text-left text-sm font-medium text-gray-700">Actions</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200">
+                {innovations.map((inv) => (
+                  <tr key={inv.id}>
+                    <td className="px-4 py-2 whitespace-nowrap">{inv.title}</td>
+                    <td className="px-4 py-2 whitespace-nowrap">{inv.registered_date ? new Date(inv.registered_date).getFullYear() : '-'}</td>
+                    <td className="px-4 py-2 whitespace-nowrap">{inv.innovation_type || '-'}</td>
+                    <td className="px-4 py-2 whitespace-nowrap">-</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
           </div>
-        </div>
-
-        {/* Quick Links */}
-        <div className="bg-gray-50 rounded-lg p-4 mb-6">
-          <h4 className="font-semibold text-gray-900 mb-3">คำร้องของฉัน</h4>
-          <div className="space-y-3">
-            {teacherData.quickLinks.map((link) => (
-              <div
-                key={link.id ?? `${link.name}-${link.destination}`}
-                className="flex items-center justify-between"
-              >
-                <span className="text-sm text-gray-600 truncate mr-2">{link.name}</span>
-                <button
-                  onClick={() => onNavigate && onNavigate('applications')}
-                  className="text-xs text-blue-600 hover:text-blue-700 whitespace-nowrap"
-                >
-                  {link.status}
-                </button>
-              </div>
-            ))}
-          </div>
-          <button
-            onClick={() => onNavigate && onNavigate('applications')}
-            className="w-full mt-4 text-center text-sm text-purple-600 hover:text-purple-700 font-medium"
-          >
-            See All
-          </button>
-        </div>
-
-        {/* Contact Information */}
-        <div className="space-y-4">
-          <div>
-            <label className="text-xs text-gray-500 uppercase tracking-wider">อีเมล</label>
-            <p className="text-sm font-medium text-gray-900 mt-1">{teacherData.email}</p>
-          </div>
-          <div>
-            <label className="text-xs text-gray-500 uppercase tracking-wider">เบอร์โทรศัพท์</label>
-            <p className="text-sm font-medium text-gray-900 mt-1">{teacherData.phone}</p>
-          </div>
-          <div>
-            <label className="text-xs text-gray-500 uppercase tracking-wider">ห้องทำงาน</label>
-            <p className="text-sm font-medium text-gray-900 mt-1">{teacherData.office}</p>
-          </div>
-          <div>
-            <label className="text-xs text-gray-500 uppercase tracking-wider">รหัสพนักงาน</label>
-            <p className="text-sm font-medium text-gray-900 mt-1">{teacherData.employeeId}</p>
-          </div>
-        </div>
+        )}
       </div>
     </div>
   );

--- a/fund-management-api/controllers/research_output.go
+++ b/fund-management-api/controllers/research_output.go
@@ -1,0 +1,36 @@
+package controllers
+
+import (
+	"net/http"
+
+	"fund-management-api/config"
+	"fund-management-api/models"
+
+	"github.com/gin-gonic/gin"
+)
+
+// GetUserPublications returns publications of current user
+func GetUserPublications(c *gin.Context) {
+	userID, _ := c.Get("userID")
+
+	var publications []models.Publication
+	if err := config.DB.Where("user_id = ?", userID).Order("publication_date DESC").Find(&publications).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch publications"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"publications": publications})
+}
+
+// GetUserInnovations returns innovations of current user
+func GetUserInnovations(c *gin.Context) {
+	userID, _ := c.Get("userID")
+
+	var innovations []models.Innovation
+	if err := config.DB.Where("user_id = ?", userID).Order("registered_date DESC").Find(&innovations).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch innovations"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"innovations": innovations})
+}

--- a/fund-management-api/models/innovation.go
+++ b/fund-management-api/models/innovation.go
@@ -1,0 +1,22 @@
+package models
+
+import "time"
+
+// Innovation represents a row in innovations table
+// Contains basic information about user's innovation records
+// Table: innovations
+
+type Innovation struct {
+	ID             int        `gorm:"primaryKey;column:id" json:"id"`
+	UserID         int        `gorm:"column:user_id" json:"user_id"`
+	Title          string     `gorm:"column:title" json:"title"`
+	InnovationType string     `gorm:"column:innovation_type" json:"innovation_type"`
+	Description    string     `gorm:"column:description" json:"description"`
+	RegisteredDate *time.Time `gorm:"column:registered_date" json:"registered_date"`
+	CreatedAt      *time.Time `gorm:"column:created_at" json:"created_at"`
+	UpdatedAt      *time.Time `gorm:"column:updated_at" json:"updated_at"`
+}
+
+func (Innovation) TableName() string {
+	return "innovations"
+}

--- a/fund-management-api/models/publication_basic.go
+++ b/fund-management-api/models/publication_basic.go
@@ -1,0 +1,22 @@
+package models
+
+import "time"
+
+// Publication represents a row in publications table
+// Contains basic information about user's published work
+// Table: publications
+
+type Publication struct {
+	ID              int        `gorm:"primaryKey;column:id" json:"id"`
+	UserID          int        `gorm:"column:user_id" json:"user_id"`
+	Title           string     `gorm:"column:title" json:"title"`
+	Journal         string     `gorm:"column:journal" json:"journal"`
+	PublicationDate *time.Time `gorm:"column:publication_date" json:"publication_date"`
+	DOI             string     `gorm:"column:doi" json:"doi"`
+	CreatedAt       *time.Time `gorm:"column:created_at" json:"created_at"`
+	UpdatedAt       *time.Time `gorm:"column:updated_at" json:"updated_at"`
+}
+
+func (Publication) TableName() string {
+	return "publications"
+}

--- a/fund-management-api/routes/routes.go
+++ b/fund-management-api/routes/routes.go
@@ -279,6 +279,10 @@ func SetupRoutes(router *gin.Engine) {
 			// Document types with category filter
 			protected.GET("/document-types", controllers.GetDocumentTypes)
 
+			// User profile related research outputs
+			protected.GET("/publications", controllers.GetUserPublications)
+			protected.GET("/innovations", controllers.GetUserInnovations)
+
 			// ===== ANNOUNCEMENTS AND FUND FORMS =====
 			announcements := protected.Group("/announcements")
 			{


### PR DESCRIPTION
## Summary
- expose user-specific publications and innovations via new API endpoints
- load publications and innovations in profile API and show tables on teacher profile
- remove extra sections, keeping only budget summary plus publications and innovations tables

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Next.js ESLint configuration prompt)*
- `go test ./...` *(no output / no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68c16cacb808832a8bc4566207be26d9