### PR TITLE
feat: add publications section to teacher profile

### DIFF
--- a/frontend_project_fund/app/lib/teacher_api.js
+++ b/frontend_project_fund/app/lib/teacher_api.js
@@ -118,6 +118,17 @@ export const teacherAPI = {
     }
   },
 
+  // Get current user's publications
+  async getUserPublications(params = {}) {
+    try {
+      const response = await apiClient.get('/teacher/user-publications', params);
+      return response;
+    } catch (error) {
+      console.error('Error fetching user publications:', error);
+      throw error;
+    }
+  },
+
   // Get teacher's applications
   async getMyApplications(params = {}) {
     try {

--- a/frontend_project_fund/app/lib/teacher_api.js
+++ b/frontend_project_fund/app/lib/teacher_api.js
@@ -129,6 +129,17 @@ export const teacherAPI = {
     }
   },
 
+  // Get current user's innovations
+  async getUserInnovations(params = {}) {
+    try {
+      const response = await apiClient.get('/teacher/user-innovations', params);
+      return response;
+    } catch (error) {
+      console.error('Error fetching user innovations:', error);
+      throw error;
+    }
+  },
+
   // Get teacher's applications
   async getMyApplications(params = {}) {
     try {

--- a/frontend_project_fund/app/teacher/components/profile/UserProfile.js
+++ b/frontend_project_fund/app/teacher/components/profile/UserProfile.js
@@ -60,9 +60,18 @@ export default function ProfileContent({ onNavigate }) {
   const [currentPage, setCurrentPage] = useState(1);
   const [rowsPerPage, setRowsPerPage] = useState(10);
 
+  const [innovations, setInnovations] = useState([]);
+  const [innovLoading, setInnovLoading] = useState(true);
+  const [innovSearchTerm, setInnovSearchTerm] = useState('');
+  const [innovSortField, setInnovSortField] = useState('registered_date');
+  const [innovSortDirection, setInnovSortDirection] = useState('desc');
+  const [innovPage, setInnovPage] = useState(1);
+  const [innovRowsPerPage, setInnovRowsPerPage] = useState(10);
+
   useEffect(() => {
     loadProfileData();
     loadPublications();
+    loadInnovations();
   }, []);
 
   const loadProfileData = async () => {
@@ -133,6 +142,19 @@ export default function ProfileContent({ onNavigate }) {
     }
   };
 
+  const loadInnovations = async () => {
+    try {
+      setInnovLoading(true);
+      const res = await teacherAPI.getUserInnovations({ limit: 1000 });
+      const items = res.data || res.items || [];
+      setInnovations(items);
+    } catch (error) {
+      console.error('Error loading innovations:', error);
+    } finally {
+      setInnovLoading(false);
+    }
+  };
+
   const handleSort = (field) => {
     if (sortField === field) {
       setSortDirection(sortDirection === 'asc' ? 'desc' : 'asc');
@@ -175,6 +197,48 @@ export default function ProfileContent({ onNavigate }) {
 
   const totalPages = Math.ceil(sortedPublications.length / rowsPerPage) || 1;
 
+  const handleInnovSort = (field) => {
+    if (innovSortField === field) {
+      setInnovSortDirection(innovSortDirection === 'asc' ? 'desc' : 'asc');
+    } else {
+      setInnovSortField(field);
+      setInnovSortDirection(field === 'registered_date' ? 'desc' : 'asc');
+    }
+  };
+
+  const innovFieldValue = (item, field) => {
+    switch (field) {
+      case 'title':
+        return item.title?.toLowerCase() || '';
+      case 'innovation_type':
+        return item.innovation_type?.toLowerCase() || '';
+      case 'registered_date':
+      default:
+        return item.registered_date || '';
+    }
+  };
+
+  const sortedInnovations = useMemo(() => {
+    const filtered = innovations.filter((i) =>
+      i.title?.toLowerCase().includes(innovSearchTerm.toLowerCase())
+    );
+    const sorted = filtered.sort((a, b) => {
+      const aVal = innovFieldValue(a, innovSortField);
+      const bVal = innovFieldValue(b, innovSortField);
+      if (aVal === bVal) return 0;
+      if (innovSortDirection === 'asc') return aVal > bVal ? 1 : -1;
+      return aVal < bVal ? 1 : -1;
+    });
+    return sorted;
+  }, [innovations, innovSearchTerm, innovSortField, innovSortDirection]);
+
+  const paginatedInnovations = useMemo(() => {
+    const start = (innovPage - 1) * innovRowsPerPage;
+    return sortedInnovations.slice(start, start + innovRowsPerPage);
+  }, [sortedInnovations, innovPage, innovRowsPerPage]);
+
+  const innovTotalPages = Math.ceil(sortedInnovations.length / innovRowsPerPage) || 1;
+
   if (loading) {
     return (
       <div className="flex items-center justify-center h-96">
@@ -190,18 +254,6 @@ export default function ProfileContent({ onNavigate }) {
     <div className="flex">
       {/* Main Content Area */}
       <div className="flex-1 lg:mr-80 p-6 space-y-8">
-        {/* Budget Summary */}
-        <section>
-          <h2 className="text-xl font-semibold text-gray-900 mb-4">สรุปงบประมาณ</h2>
-          <BudgetSummary
-            budget={{
-              total: teacherData.stats.totalBudgetReceived,
-              thisYear: teacherData.stats.usedBudget,
-              remaining: teacherData.stats.remainingBudget
-            }}
-          />
-        </section>
-
         {/* Publications */}
         <section>
           <h2 className="text-xl font-semibold text-gray-900 mb-4">ผลงานตีพิมพ์ (Publications)</h2>
@@ -364,6 +416,157 @@ export default function ProfileContent({ onNavigate }) {
               </>
             )}
           </div>
+        </section>
+
+        {/* Innovations */}
+        <section>
+          <h2 className="text-xl font-semibold text-gray-900 mb-4">นวัตกรรม (Innovations)</h2>
+          <div className="mb-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+            <input
+              type="text"
+              value={innovSearchTerm}
+              onChange={(e) => {
+                setInnovSearchTerm(e.target.value);
+                setInnovPage(1);
+              }}
+              placeholder="ค้นหาชื่อเรื่อง..."
+              className="border border-gray-300 rounded-md px-3 py-2 w-full sm:w-64 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-gray-600">แสดง</span>
+              <select
+                value={innovRowsPerPage}
+                onChange={(e) => {
+                  setInnovRowsPerPage(parseInt(e.target.value));
+                  setInnovPage(1);
+                }}
+                className="border border-gray-300 rounded-md px-2 py-2 text-sm"
+              >
+                <option value={10}>10</option>
+                <option value={20}>20</option>
+              </select>
+              <span className="text-sm text-gray-600">รายการ</span>
+            </div>
+          </div>
+
+          <div className="overflow-x-auto">
+            {innovLoading ? (
+              <div className="space-y-2 animate-pulse">
+                {[...Array(5)].map((_, i) => (
+                  <div key={i} className="h-6 bg-gray-100 rounded" />
+                ))}
+              </div>
+            ) : sortedInnovations.length === 0 ? (
+              <p className="text-center text-gray-500 py-6">ยังไม่มีนวัตกรรม</p>
+            ) : (
+              <>
+                <table className="min-w-full divide-y divide-gray-200 text-sm">
+                  <thead className="bg-gray-50">
+                    <tr>
+                      <th
+                        className="px-4 py-2 text-left font-medium text-gray-700 cursor-pointer"
+                        onClick={() => handleInnovSort('title')}
+                      >
+                        ชื่อเรื่อง
+                        {innovSortField === 'title' ? (
+                          innovSortDirection === 'asc' ? (
+                            <ArrowUp className="inline ml-1" size={14} />
+                          ) : (
+                            <ArrowDown className="inline ml-1" size={14} />
+                          )
+                        ) : (
+                          <ArrowUpDown className="inline ml-1 text-gray-400" size={14} />
+                        )}
+                      </th>
+                      <th
+                        className="px-4 py-2 text-left font-medium text-gray-700 cursor-pointer w-40"
+                        onClick={() => handleInnovSort('innovation_type')}
+                      >
+                        ประเภท
+                        {innovSortField === 'innovation_type' ? (
+                          innovSortDirection === 'asc' ? (
+                            <ArrowUp className="inline ml-1" size={14} />
+                          ) : (
+                            <ArrowDown className="inline ml-1" size={14} />
+                          )
+                        ) : (
+                          <ArrowUpDown className="inline ml-1 text-gray-400" size={14} />
+                        )}
+                      </th>
+                      <th
+                        className="px-4 py-2 text-center font-medium text-gray-700 w-32 cursor-pointer"
+                        onClick={() => handleInnovSort('registered_date')}
+                      >
+                        วันที่จดทะเบียน
+                        {innovSortField === 'registered_date' ? (
+                          innovSortDirection === 'asc' ? (
+                            <ArrowUp className="inline ml-1" size={14} />
+                          ) : (
+                            <ArrowDown className="inline ml-1" size={14} />
+                          )
+                        ) : (
+                          <ArrowUpDown className="inline ml-1 text-gray-400" size={14} />
+                        )}
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-200">
+                    {paginatedInnovations.map((inv) => (
+                      <tr key={inv.id} className="hover:bg-gray-50">
+                        <td className="px-4 py-2 max-w-xs lg:max-w-md">
+                          <span className="truncate block" title={inv.title}>
+                            {inv.title}
+                          </span>
+                        </td>
+                        <td className="px-4 py-2">
+                          <span className="truncate block" title={inv.innovation_type}>
+                            {inv.innovation_type || '-'}
+                          </span>
+                        </td>
+                        <td className="px-4 py-2 text-center">
+                          {inv.registered_date || '-'}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+                <div className="flex items-center justify-between mt-4 text-sm">
+                  <span className="text-gray-600">
+                    แสดง { (innovPage - 1) * innovRowsPerPage + 1 }-
+                    { Math.min(innovPage * innovRowsPerPage, sortedInnovations.length) } จาก { sortedInnovations.length }
+                  </span>
+                  <div className="space-x-2">
+                    <button
+                      onClick={() => setInnovPage((p) => Math.max(1, p - 1))}
+                      disabled={innovPage === 1}
+                      className="px-3 py-1 border rounded disabled:opacity-50"
+                    >
+                      ก่อนหน้า
+                    </button>
+                    <button
+                      onClick={() => setInnovPage((p) => Math.min(innovTotalPages, p + 1))}
+                      disabled={innovPage === innovTotalPages}
+                      className="px-3 py-1 border rounded disabled:opacity-50"
+                    >
+                      ถัดไป
+                    </button>
+                  </div>
+                </div>
+              </>
+            )}
+          </div>
+        </section>
+
+        {/* Budget Summary */}
+        <section>
+          <h2 className="text-xl font-semibold text-gray-900 mb-4">สรุปงบประมาณ</h2>
+          <BudgetSummary
+            budget={{
+              total: teacherData.stats.totalBudgetReceived,
+              thisYear: teacherData.stats.usedBudget,
+              remaining: teacherData.stats.remainingBudget
+            }}
+          />
         </section>
       </div>
 

--- a/frontend_project_fund/app/teacher/components/profile/UserProfile.js
+++ b/frontend_project_fund/app/teacher/components/profile/UserProfile.js
@@ -1,4 +1,6 @@
-import React, { useState, useEffect } from 'react';
+"use client";
+
+import React, { useState, useEffect, useMemo } from 'react';
 import {
   User,
   Mail,
@@ -11,11 +13,15 @@ import {
   Bell,
   Settings,
   Camera,
-  Activity
+  Activity,
+  ArrowUp,
+  ArrowDown,
+  ArrowUpDown
 } from 'lucide-react';
 
 import profileAPI from '@/app/lib/profile_api';
 import teacherAPI from '@/app/lib/teacher_api';
+import BudgetSummary from '@/app/teacher/components/dashboard/BudgetSummary';
 
 // Default data structure for the profile
 const defaultTeacherData = {
@@ -46,9 +52,17 @@ const defaultTeacherData = {
 export default function ProfileContent({ onNavigate }) {
   const [teacherData, setTeacherData] = useState(defaultTeacherData);
   const [loading, setLoading] = useState(true);
+  const [publications, setPublications] = useState([]);
+  const [pubLoading, setPubLoading] = useState(true);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [sortField, setSortField] = useState('year');
+  const [sortDirection, setSortDirection] = useState('desc');
+  const [currentPage, setCurrentPage] = useState(1);
+  const [rowsPerPage, setRowsPerPage] = useState(10);
 
   useEffect(() => {
     loadProfileData();
+    loadPublications();
   }, []);
 
   const loadProfileData = async () => {
@@ -106,6 +120,61 @@ export default function ProfileContent({ onNavigate }) {
     }
   };
 
+  const loadPublications = async () => {
+    try {
+      setPubLoading(true);
+      const res = await teacherAPI.getUserPublications({ limit: 1000 });
+      const items = res.data || res.items || [];
+      setPublications(items);
+    } catch (error) {
+      console.error('Error loading publications:', error);
+    } finally {
+      setPubLoading(false);
+    }
+  };
+
+  const handleSort = (field) => {
+    if (sortField === field) {
+      setSortDirection(sortDirection === 'asc' ? 'desc' : 'asc');
+    } else {
+      setSortField(field);
+      setSortDirection(field === 'year' ? 'desc' : 'asc');
+    }
+  };
+
+  const fieldValue = (item, field) => {
+    switch (field) {
+      case 'title':
+        return item.title?.toLowerCase() || '';
+      case 'cited_by':
+        return item.cited_by || 0;
+      case 'year':
+      default:
+        return item.publication_year || 0;
+    }
+  };
+
+  const sortedPublications = useMemo(() => {
+    const filtered = publications.filter((p) =>
+      p.title?.toLowerCase().includes(searchTerm.toLowerCase())
+    );
+    const sorted = filtered.sort((a, b) => {
+      const aVal = fieldValue(a, sortField);
+      const bVal = fieldValue(b, sortField);
+      if (aVal === bVal) return 0;
+      if (sortDirection === 'asc') return aVal > bVal ? 1 : -1;
+      return aVal < bVal ? 1 : -1;
+    });
+    return sorted;
+  }, [publications, searchTerm, sortField, sortDirection]);
+
+  const paginatedPublications = useMemo(() => {
+    const start = (currentPage - 1) * rowsPerPage;
+    return sortedPublications.slice(start, start + rowsPerPage);
+  }, [sortedPublications, currentPage, rowsPerPage]);
+
+  const totalPages = Math.ceil(sortedPublications.length / rowsPerPage) || 1;
+
   if (loading) {
     return (
       <div className="flex items-center justify-center h-96">
@@ -120,6 +189,183 @@ export default function ProfileContent({ onNavigate }) {
   return (
     <div className="flex">
       {/* Main Content Area */}
+      <div className="flex-1 lg:mr-80 p-6 space-y-8">
+        {/* Budget Summary */}
+        <section>
+          <h2 className="text-xl font-semibold text-gray-900 mb-4">สรุปงบประมาณ</h2>
+          <BudgetSummary
+            budget={{
+              total: teacherData.stats.totalBudgetReceived,
+              thisYear: teacherData.stats.usedBudget,
+              remaining: teacherData.stats.remainingBudget
+            }}
+          />
+        </section>
+
+        {/* Publications */}
+        <section>
+          <h2 className="text-xl font-semibold text-gray-900 mb-4">ผลงานตีพิมพ์ (Publications)</h2>
+          <div className="mb-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+            <input
+              type="text"
+              value={searchTerm}
+              onChange={(e) => {
+                setSearchTerm(e.target.value);
+                setCurrentPage(1);
+              }}
+              placeholder="ค้นหาชื่อเรื่อง..."
+              className="border border-gray-300 rounded-md px-3 py-2 w-full sm:w-64 focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            <div className="flex items-center gap-2">
+              <span className="text-sm text-gray-600">แสดง</span>
+              <select
+                value={rowsPerPage}
+                onChange={(e) => {
+                  setRowsPerPage(parseInt(e.target.value));
+                  setCurrentPage(1);
+                }}
+                className="border border-gray-300 rounded-md px-2 py-2 text-sm"
+              >
+                <option value={10}>10</option>
+                <option value={20}>20</option>
+              </select>
+              <span className="text-sm text-gray-600">รายการ</span>
+            </div>
+          </div>
+
+          <div className="overflow-x-auto">
+            {pubLoading ? (
+              <div className="space-y-2 animate-pulse">
+                {[...Array(5)].map((_, i) => (
+                  <div key={i} className="h-6 bg-gray-100 rounded" />
+                ))}
+              </div>
+            ) : sortedPublications.length === 0 ? (
+              <p className="text-center text-gray-500 py-6">ยังไม่มีผลงานตีพิมพ์</p>
+            ) : (
+              <>
+                <table className="min-w-full divide-y divide-gray-200 text-sm">
+                  <thead className="bg-gray-50">
+                    <tr>
+                      <th
+                        className="px-4 py-2 text-left font-medium text-gray-700 cursor-pointer"
+                        onClick={() => handleSort('title')}
+                      >
+                        ชื่อเรื่อง
+                        {sortField === 'title' ? (
+                          sortDirection === 'asc' ? (
+                            <ArrowUp className="inline ml-1" size={14} />
+                          ) : (
+                            <ArrowDown className="inline ml-1" size={14} />
+                          )
+                        ) : (
+                          <ArrowUpDown className="inline ml-1 text-gray-400" size={14} />
+                        )}
+                      </th>
+                      <th
+                        className="px-4 py-2 text-right font-medium text-gray-700 w-24 cursor-pointer"
+                        onClick={() => handleSort('cited_by')}
+                      >
+                        อ้างโดย
+                        {sortField === 'cited_by' ? (
+                          sortDirection === 'asc' ? (
+                            <ArrowUp className="inline ml-1" size={14} />
+                          ) : (
+                            <ArrowDown className="inline ml-1" size={14} />
+                          )
+                        ) : (
+                          <ArrowUpDown className="inline ml-1 text-gray-400" size={14} />
+                        )}
+                      </th>
+                      <th
+                        className="px-4 py-2 text-center font-medium text-gray-700 w-20 cursor-pointer"
+                        onClick={() => handleSort('year')}
+                      >
+                        ปี
+                        {sortField === 'year' ? (
+                          sortDirection === 'asc' ? (
+                            <ArrowUp className="inline ml-1" size={14} />
+                          ) : (
+                            <ArrowDown className="inline ml-1" size={14} />
+                          )
+                        ) : (
+                          <ArrowUpDown className="inline ml-1 text-gray-400" size={14} />
+                        )}
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-200">
+                    {paginatedPublications.map((pub) => (
+                      <tr key={pub.id} className="hover:bg-gray-50">
+                        <td className="px-4 py-2 max-w-xs lg:max-w-md">
+                          {pub.url ? (
+                            <a
+                              href={pub.url}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              className="text-blue-600 hover:underline truncate block"
+                              title={pub.title}
+                            >
+                              {pub.title}
+                            </a>
+                          ) : (
+                            <span className="truncate block" title={pub.title}>
+                              {pub.title}
+                            </span>
+                          )}
+                        </td>
+                        <td className="px-4 py-2 text-right">
+                          {pub.cited_by ? (
+                            pub.cited_by_url ? (
+                              <a
+                                href={pub.cited_by_url}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="text-blue-600 hover:underline"
+                              >
+                                {pub.cited_by}
+                              </a>
+                            ) : (
+                              <span>{pub.cited_by}</span>
+                            )
+                          ) : (
+                            <span>-</span>
+                          )}
+                        </td>
+                        <td className="px-4 py-2 text-center">
+                          {pub.publication_year || '-'}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+                <div className="flex items-center justify-between mt-4 text-sm">
+                  <span className="text-gray-600">
+                    แสดง { (currentPage - 1) * rowsPerPage + 1 }-
+                    { Math.min(currentPage * rowsPerPage, sortedPublications.length) } จาก { sortedPublications.length }
+                  </span>
+                  <div className="space-x-2">
+                    <button
+                      onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
+                      disabled={currentPage === 1}
+                      className="px-3 py-1 border rounded disabled:opacity-50"
+                    >
+                      ก่อนหน้า
+                    </button>
+                    <button
+                      onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
+                      disabled={currentPage === totalPages}
+                      className="px-3 py-1 border rounded disabled:opacity-50"
+                    >
+                      ถัดไป
+                    </button>
+                  </div>
+                </div>
+              </>
+            )}
+          </div>
+        </section>
+      </div>
 
       {/* Right Sidebar - Fixed Position */}
       <div className="hidden lg:block fixed right-0 top-20 bottom-0 w-80 p-6 bg-white border-l border-gray-200 overflow-y-auto">

--- a/fund-management-api/controllers/user_innovation.go
+++ b/fund-management-api/controllers/user_innovation.go
@@ -1,0 +1,48 @@
+package controllers
+
+import (
+	"net/http"
+	"strconv"
+
+	"fund-management-api/services"
+
+	"github.com/gin-gonic/gin"
+)
+
+// GET /api/v1/teacher/user-innovations?limit=50&offset=0
+func GetUserInnovations(c *gin.Context) {
+	userID, ok := getUserIDFromContext(c)
+	if !ok {
+		q := c.Query("user_id")
+		if q == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "user_id not found"})
+			return
+		}
+		id64, err := strconv.ParseUint(q, 10, 64)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"success": false, "error": "invalid user_id"})
+			return
+		}
+		userID = uint(id64)
+	}
+
+	limit := parseIntOrDefault(c.Query("limit"), 50)
+	offset := parseIntOrDefault(c.Query("offset"), 0)
+
+	svc := services.NewInnovationService(nil)
+	items, total, err := svc.ListByUser(userID, limit, offset)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"data":    items,
+		"paging": gin.H{
+			"total":  total,
+			"limit":  limit,
+			"offset": offset,
+		},
+	})
+}

--- a/fund-management-api/models/innovation.go
+++ b/fund-management-api/models/innovation.go
@@ -1,0 +1,16 @@
+package models
+
+import "time"
+
+type Innovation struct {
+	ID             uint       `json:"id" gorm:"primaryKey;autoIncrement"`
+	UserID         uint       `json:"user_id" gorm:"not null;index"`
+	Title          string     `json:"title" gorm:"type:varchar(500);not null"`
+	InnovationType *string    `json:"innovation_type,omitempty" gorm:"type:varchar(255)"`
+	Description    *string    `json:"description,omitempty" gorm:"type:text"`
+	RegisteredDate *time.Time `json:"registered_date,omitempty" gorm:"type:date"`
+	CreatedAt      time.Time  `json:"created_at" gorm:"column:created_at;autoCreateTime"`
+	UpdatedAt      time.Time  `json:"updated_at" gorm:"column:updated_at;autoUpdateTime"`
+}
+
+func (Innovation) TableName() string { return "innovations" }

--- a/fund-management-api/routes/routes.go
+++ b/fund-management-api/routes/routes.go
@@ -140,6 +140,9 @@ func SetupRoutes(router *gin.Engine) {
 				teacher.DELETE("/user-publications/:id", controllers.DeleteUserPublication)
 				teacher.PATCH("/user-publications/:id/restore", controllers.RestoreUserPublication)
 				teacher.GET("/user-publications/scholar/search", controllers.TeacherScholarAuthorSearch)
+
+				// User Innovations
+				teacher.GET("/user-innovations", controllers.GetUserInnovations)
 			}
 
 			// Staff-specific endpoints

--- a/fund-management-api/services/innovation_service.go
+++ b/fund-management-api/services/innovation_service.go
@@ -1,0 +1,41 @@
+package services
+
+import (
+	"fund-management-api/config"
+	"fund-management-api/models"
+	"gorm.io/gorm"
+)
+
+type InnovationService struct {
+	db *gorm.DB
+}
+
+func NewInnovationService(db *gorm.DB) *InnovationService {
+	if db == nil {
+		db = config.DB
+	}
+	return &InnovationService{db: db}
+}
+
+func (s *InnovationService) ListByUser(userID uint, limit, offset int) ([]models.Innovation, int64, error) {
+	if limit <= 0 {
+		limit = 50
+	}
+	if offset < 0 {
+		offset = 0
+	}
+
+	var items []models.Innovation
+	q := s.db.Model(&models.Innovation{}).Where("user_id = ?", userID)
+
+	var total int64
+	if err := q.Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	if err := q.Order("registered_date DESC, id DESC").Limit(limit).Offset(offset).Find(&items).Error; err != nil {
+		return nil, 0, err
+	}
+
+	return items, total, nil
+}


### PR DESCRIPTION
## Summary
- fetch user publications from API and render on teacher profile
- add sortable, searchable, paginated publications table with loading states
- include budget summary in main profile content

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(interactive: next lint prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68c561d999dc832a81faf7eba4222456