### PR TITLE
Add scholar-style citations summary to teacher profile

### DIFF
--- a/frontend_project_fund/app/teacher/components/profile/UserProfile.js
+++ b/frontend_project_fund/app/teacher/components/profile/UserProfile.js
@@ -142,45 +142,56 @@ const ScholarCitationsCard = ({ loading, metrics, formatNumber }) => {
               )}
             </div>
             {chartData.length > 0 ? (
-              <div className="mt-3 overflow-x-auto">
-                <div className="flex h-32 items-end gap-3">
-                  {chartData.map(({ year, value }) => {
-                    const numericValue = typeof value === "number" ? value : Number(value) || 0;
-                    const barStyle =
-                      chartMax > 0
-                        ? {
-                            height: `${Math.max(
-                              numericValue > 0 ? (numericValue / chartMax) * 100 : 0,
-                              numericValue > 0 ? 8 : 0,
-                            )}%`,
-                          }
-                        : { height: numericValue > 0 ? "100%" : "6px" };
-                    const formattedValue =
-                      typeof numericValue === "number"
-                        ? (formatNumber ? formatNumber(numericValue) : numericValue)
-                        : numericValue;
-                    return (
-                      <div
-                        key={year}
-                        className="flex min-w-[48px] flex-col items-center text-[11px] text-gray-500"
-                      >
-                        <div className="group relative flex h-24 w-6 items-end justify-center">
-                          <div
-                            className="relative w-full rounded-md bg-blue-100 shadow-sm transition-colors duration-150 group-hover:bg-blue-200"
-                            style={barStyle}
-                          >
-                            <div className="pointer-events-none absolute bottom-full left-1/2 mb-2 -translate-x-1/2 -translate-y-full opacity-0 whitespace-nowrap rounded-md bg-gray-800 px-2 py-1 text-xs text-white shadow-lg transition-opacity duration-150 group-hover:opacity-100">
-                              <div className="font-medium">
-                                {formattedValue ?? "-"} {chartValueLabel}
+              <div className="mt-4 overflow-x-auto">
+                <div className="relative">
+                  <div className="pointer-events-none absolute inset-x-6 top-4 bottom-12">
+                    <div className="flex h-full flex-col justify-between">
+                      {[...Array(4)].map((_, idx) => (
+                        <div
+                          key={`grid-${idx}`}
+                          className={`h-px w-full ${
+                            idx === 0 ? "border-t border-slate-200/80" : "border-t border-dashed border-slate-200/70"
+                          }`}
+                        />
+                      ))}
+                    </div>
+                  </div>
+                  <div className="flex h-48 min-w-max items-end gap-4 px-6 pb-12 pt-4">
+                    {chartData.map(({ year, value }) => {
+                      const numericValue = typeof value === "number" ? value : Number(value) || 0;
+                      const ratio =
+                        chartMax > 0
+                          ? (numericValue / chartMax) * 100
+                          : numericValue > 0
+                            ? 100
+                            : 0;
+                      const basePercent = numericValue > 0 ? Math.max(ratio, 8) : 0;
+                      const barPercent = Math.min(basePercent, 100);
+                      const formattedValue =
+                        typeof numericValue === "number"
+                          ? (formatNumber ? formatNumber(numericValue) : numericValue)
+                          : numericValue;
+                      return (
+                        <div
+                          key={year}
+                          className="group flex h-full min-w-[56px] flex-1 flex-col items-center justify-end text-[11px] text-gray-500"
+                        >
+                          <div className="flex h-full w-full items-end">
+                            <div
+                              className="relative w-full overflow-visible rounded-lg bg-gradient-to-t from-blue-500/80 via-blue-400 to-blue-300 shadow-sm transition-all duration-200 group-hover:from-blue-600 group-hover:via-blue-500 group-hover:to-blue-400"
+                              style={{ height: `${barPercent}%` }}
+                            >
+                              <div className="pointer-events-none absolute left-1/2 top-0 -translate-x-1/2 -translate-y-2 whitespace-nowrap rounded-md bg-slate-900/90 px-2 py-1 text-xs font-medium text-white opacity-0 shadow-lg transition-all duration-150 group-hover:-translate-y-3 group-hover:opacity-100">
+                                <div>{formattedValue ?? "-"} {chartValueLabel}</div>
+                                <div className="text-[10px] font-normal text-slate-300">{year}</div>
                               </div>
-                              <div className="text-[10px] text-gray-200">{year}</div>
                             </div>
                           </div>
+                          <span className="mt-3 text-xs font-medium text-gray-600">{year}</span>
                         </div>
-                        <span className="mt-2 font-medium text-gray-600">{year}</span>
-                      </div>
-                    );
-                  })}
+                      );
+                    })}
+                  </div>
                 </div>
               </div>
             ) : hasSummaryData ? (

--- a/frontend_project_fund/app/teacher/components/profile/UserProfile.js
+++ b/frontend_project_fund/app/teacher/components/profile/UserProfile.js
@@ -43,6 +43,158 @@ const defaultTeacherData = {
   quickLinks: [],
 };
 
+const CITATION_RECENT_START_YEAR = 2020;
+
+const ScholarCitationsCard = ({ loading, metrics, formatNumber }) => {
+  const totals = metrics?.totals || { all: null, recent: null };
+  const hIndex = metrics?.hIndex || { all: null, recent: null };
+  const i10Index = metrics?.i10Index || { all: null, recent: null };
+  const chart = metrics?.chart || { data: [], isCitations: true };
+
+  const renderValue = (value) => {
+    if (value === null || value === undefined) {
+      return "-";
+    }
+    if (typeof value === "number") {
+      const formatted = formatNumber ? formatNumber(value) : value;
+      return formatted ?? value;
+    }
+    return value;
+  };
+
+  const chartData = Array.isArray(chart.data) ? chart.data : [];
+  const chartMax = chartData.reduce(
+    (max, item) => (typeof item.value === "number" && item.value > max ? item.value : max),
+    0,
+  );
+
+  const chartUnitLabel = chart.isCitations ? "การอ้างอิงต่อปี" : "จำนวนผลงานต่อปี";
+  const chartValueLabel = chart.isCitations ? "การอ้างอิง" : "ผลงาน";
+
+  const hasSummaryData =
+    totals.all !== null ||
+    totals.recent !== null ||
+    hIndex.all !== null ||
+    hIndex.recent !== null ||
+    i10Index.all !== null ||
+    i10Index.recent !== null;
+
+  return (
+    <div className="mt-6 rounded-xl border border-gray-100 bg-gradient-to-br from-white via-white to-slate-50 p-4 shadow-inner">
+      <h3 className="text-lg font-semibold text-gray-900">อ้างโดย</h3>
+      {loading ? (
+        <div className="mt-4 space-y-3">
+          <div className="h-16 animate-pulse rounded-md bg-gray-100" />
+          <div className="h-28 animate-pulse rounded-md bg-gray-100" />
+        </div>
+      ) : (
+        <>
+          <div className="mt-4 overflow-hidden rounded-lg border border-gray-200">
+            <table className="w-full text-sm text-gray-700">
+              <thead className="bg-gray-50 text-gray-500">
+                <tr>
+                  <th className="px-4 py-2 text-left font-medium">&nbsp;</th>
+                  <th className="px-4 py-2 text-right font-medium">ทั้งหมด</th>
+                  <th className="px-4 py-2 text-right font-medium">
+                    ตั้งแต่ปี {CITATION_RECENT_START_YEAR}
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr className="odd:bg-white even:bg-gray-50">
+                  <td className="px-4 py-2 font-medium text-gray-600">การอ้างอิง</td>
+                  <td className="px-4 py-2 text-right font-semibold text-gray-900">
+                    {renderValue(totals.all)}
+                  </td>
+                  <td className="px-4 py-2 text-right font-semibold text-gray-900">
+                    {renderValue(totals.recent)}
+                  </td>
+                </tr>
+                <tr className="odd:bg-white even:bg-gray-50">
+                  <td className="px-4 py-2 font-medium text-gray-600">ดัชนี h</td>
+                  <td className="px-4 py-2 text-right font-semibold text-gray-900">
+                    {renderValue(hIndex.all)}
+                  </td>
+                  <td className="px-4 py-2 text-right font-semibold text-gray-900">
+                    {renderValue(hIndex.recent)}
+                  </td>
+                </tr>
+                <tr className="odd:bg-white even:bg-gray-50">
+                  <td className="px-4 py-2 font-medium text-gray-600">ดัชนี i10</td>
+                  <td className="px-4 py-2 text-right font-semibold text-gray-900">
+                    {renderValue(i10Index.all)}
+                  </td>
+                  <td className="px-4 py-2 text-right font-semibold text-gray-900">
+                    {renderValue(i10Index.recent)}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <div className="mt-6">
+            <div className="flex items-center justify-between text-xs text-gray-500">
+              <span>{chartUnitLabel}</span>
+              {chart.isCitations ? null : (
+                <span className="italic text-[11px] text-gray-400">
+                  TODO: เปลี่ยนเป็นจำนวนการอ้างอิงเมื่อมีข้อมูล
+                </span>
+              )}
+            </div>
+            {chartData.length > 0 ? (
+              <div className="mt-3 overflow-x-auto">
+                <div className="flex h-32 items-end gap-3">
+                  {chartData.map(({ year, value }) => {
+                    const numericValue = typeof value === "number" ? value : Number(value) || 0;
+                    const barStyle =
+                      chartMax > 0
+                        ? {
+                            height: `${Math.max(
+                              numericValue > 0 ? (numericValue / chartMax) * 100 : 0,
+                              numericValue > 0 ? 8 : 0,
+                            )}%`,
+                          }
+                        : { height: numericValue > 0 ? "100%" : "6px" };
+                    const formattedValue =
+                      typeof numericValue === "number"
+                        ? (formatNumber ? formatNumber(numericValue) : numericValue)
+                        : numericValue;
+                    return (
+                      <div
+                        key={year}
+                        className="flex min-w-[48px] flex-col items-center text-[11px] text-gray-500"
+                      >
+                        <div className="group relative flex h-24 w-6 items-end justify-center">
+                          <div
+                            className="relative w-full rounded-md bg-blue-100 shadow-sm transition-colors duration-150 group-hover:bg-blue-200"
+                            style={barStyle}
+                          >
+                            <div className="pointer-events-none absolute bottom-full left-1/2 mb-2 -translate-x-1/2 -translate-y-full opacity-0 whitespace-nowrap rounded-md bg-gray-800 px-2 py-1 text-xs text-white shadow-lg transition-opacity duration-150 group-hover:opacity-100">
+                              <div className="font-medium">
+                                {formattedValue ?? "-"} {chartValueLabel}
+                              </div>
+                              <div className="text-[10px] text-gray-200">{year}</div>
+                            </div>
+                          </div>
+                        </div>
+                        <span className="mt-2 font-medium text-gray-600">{year}</span>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            ) : hasSummaryData ? (
+              <p className="mt-3 text-sm text-gray-500">ไม่มีข้อมูลเพียงพอสำหรับสร้างกราฟ</p>
+            ) : (
+              <p className="mt-3 text-sm text-gray-500">ยังไม่มีข้อมูลการอ้างอิง</p>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
 export default function ProfileContent() {
   const [teacherData, setTeacherData] = useState(defaultTeacherData);
   const [loading, setLoading] = useState(true);
@@ -216,6 +368,170 @@ export default function ProfileContent() {
     const start = (currentPage - 1) * rowsPerPage;
     return sortedPublications.slice(start, start + rowsPerPage);
   }, [sortedPublications, currentPage, rowsPerPage]);
+
+  const citationMetrics = useMemo(() => {
+    if (!publications || publications.length === 0) {
+      return {
+        totals: { all: null, recent: null },
+        hIndex: { all: null, recent: null },
+        i10Index: { all: null, recent: null },
+        chart: { data: [], isCitations: true },
+      };
+    }
+
+    const toNumber = (value) => {
+      if (value === null || value === undefined) return null;
+      if (typeof value === "string") {
+        const trimmed = value.trim();
+        if (trimmed === "") return null;
+        const num = Number(trimmed);
+        return Number.isFinite(num) ? num : null;
+      }
+      const num = Number(value);
+      return Number.isFinite(num) ? num : null;
+    };
+
+    const parseHistory = (raw) => {
+      if (!raw) return {};
+      let parsed = raw;
+      if (typeof raw === "string") {
+        try {
+          parsed = JSON.parse(raw);
+        } catch {
+          return {};
+        }
+      }
+      if (Array.isArray(parsed)) {
+        return parsed.reduce((acc, entry) => {
+          if (Array.isArray(entry) && entry.length >= 2) {
+            const [year, count] = entry;
+            if (year !== undefined && count !== undefined) {
+              acc[year] = count;
+            }
+          } else if (entry && typeof entry === "object") {
+            const year = entry.year ?? entry.Year ?? entry.y;
+            const count =
+              entry.citations ??
+              entry.Citations ??
+              entry.count ??
+              entry.value ??
+              entry.total;
+            if (year !== undefined && count !== undefined) {
+              acc[year] = count;
+            }
+          }
+          return acc;
+        }, {});
+      }
+      if (parsed && typeof parsed === "object") {
+        return parsed;
+      }
+      return {};
+    };
+
+    const perYearMap = new Map();
+    const publicationCountMap = new Map();
+    const allCitationCounts = [];
+    const recentCitationCounts = [];
+    let totalCitations = 0;
+
+    publications.forEach((pub) => {
+      if (Object.prototype.hasOwnProperty.call(pub, "cited_by")) {
+        const totalCited = toNumber(pub.cited_by);
+        if (totalCited !== null) {
+          totalCitations += totalCited;
+          allCitationCounts.push(totalCited);
+        }
+      }
+
+      const pubYear = toNumber(pub.publication_year);
+      if (pubYear !== null) {
+        publicationCountMap.set(
+          pubYear,
+          (publicationCountMap.get(pubYear) || 0) + 1,
+        );
+      }
+
+      const history = parseHistory(pub.citation_history);
+      const entries = Object.entries(history);
+      if (entries.length > 0) {
+        let recentSumForPub = 0;
+        entries.forEach(([yearKey, rawCount]) => {
+          const yearNum = Number(yearKey);
+          const countNum = toNumber(rawCount);
+          if (!Number.isFinite(yearNum) || countNum === null) return;
+          perYearMap.set(yearNum, (perYearMap.get(yearNum) || 0) + countNum);
+          if (yearNum >= CITATION_RECENT_START_YEAR) {
+            recentSumForPub += countNum;
+          }
+        });
+        recentCitationCounts.push(recentSumForPub);
+      }
+    });
+
+    const computeHIndex = (values) => {
+      if (!values || values.length === 0) return 0;
+      const sorted = [...values].sort((a, b) => b - a);
+      let h = 0;
+      for (let i = 0; i < sorted.length; i += 1) {
+        if (sorted[i] >= i + 1) {
+          h = i + 1;
+        } else {
+          break;
+        }
+      }
+      return h;
+    };
+
+    const computeI10 = (values) => {
+      if (!values || values.length === 0) return 0;
+      return values.filter((val) => val >= 10).length;
+    };
+
+    const hasOverallCitations = allCitationCounts.length > 0;
+    const hasPerYearCitations = perYearMap.size > 0;
+
+    let chartData = [];
+    let isCitationsChart = true;
+    if (hasPerYearCitations) {
+      chartData = Array.from(perYearMap.entries())
+        .sort((a, b) => a[0] - b[0])
+        .map(([year, value]) => ({ year, value }));
+    } else {
+      isCitationsChart = false;
+      // TODO: Switch to citation counts once the API exposes per-year citation data.
+      chartData = Array.from(publicationCountMap.entries())
+        .sort((a, b) => a[0] - b[0])
+        .map(([year, value]) => ({ year, value }));
+    }
+
+    const recentTotal = hasPerYearCitations
+      ? Array.from(perYearMap.entries()).reduce(
+          (sum, [year, value]) =>
+            year >= CITATION_RECENT_START_YEAR ? sum + value : sum,
+          0,
+        )
+      : null;
+
+    return {
+      totals: {
+        all: hasOverallCitations ? totalCitations : null,
+        recent: hasPerYearCitations ? recentTotal : null,
+      },
+      hIndex: {
+        all: hasOverallCitations ? computeHIndex(allCitationCounts) : null,
+        recent: hasPerYearCitations ? computeHIndex(recentCitationCounts) : null,
+      },
+      i10Index: {
+        all: hasOverallCitations ? computeI10(allCitationCounts) : null,
+        recent: hasPerYearCitations ? computeI10(recentCitationCounts) : null,
+      },
+      chart: {
+        data: chartData,
+        isCitations: isCitationsChart,
+      },
+    };
+  }, [publications]);
 
   const totalPages = Math.ceil(sortedPublications.length / rowsPerPage) || 1;
 
@@ -634,6 +950,11 @@ export default function ProfileContent() {
                 </>
               )}
             </div>
+            <ScholarCitationsCard
+              loading={pubLoading}
+              metrics={citationMetrics}
+              formatNumber={formatNumber}
+            />
           </section>
 
           <section className="rounded-2xl border border-gray-100 bg-white p-6 shadow-sm">

--- a/frontend_project_fund/app/teacher/components/profile/UserProfile.js
+++ b/frontend_project_fund/app/teacher/components/profile/UserProfile.js
@@ -224,6 +224,7 @@ export default function ProfileContent() {
   const [innovSortDirection, setInnovSortDirection] = useState("desc");
   const [innovPage, setInnovPage] = useState(1);
   const [innovRowsPerPage, setInnovRowsPerPage] = useState(10);
+  const [activeTab, setActiveTab] = useState("publications");
 
   useEffect(() => {
     loadProfileData();
@@ -782,345 +783,374 @@ export default function ProfileContent() {
 
         <div className="space-y-8">
           <section className="rounded-2xl border border-gray-100 bg-white p-6 shadow-sm">
-            <div className="mb-4 flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-              <h2 className="text-xl font-semibold text-gray-900">
-                ผลงานตีพิมพ์ (Publications)
-              </h2>
-              <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-4">
-                <input
-                  type="text"
-                  value={searchTerm}
-                  onChange={(e) => {
-                    setSearchTerm(e.target.value);
-                    setCurrentPage(1);
-                  }}
-                  placeholder="ค้นหาชื่อเรื่อง..."
-                  className="w-full rounded-md border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 sm:w-64"
-                />
-                <div className="flex items-center gap-2 text-sm text-gray-600">
-                  <span>แสดง</span>
-                  <select
-                    value={rowsPerPage}
-                    onChange={(e) => {
-                      setRowsPerPage(parseInt(e.target.value));
-                      setCurrentPage(1);
-                    }}
-                    className="rounded-md border border-gray-300 px-2 py-2"
-                  >
-                    <option value={10}>10</option>
-                    <option value={20}>20</option>
-                  </select>
-                  <span>รายการ</span>
-                </div>
-              </div>
+            <div className="mb-6 border-b border-gray-200">
+              <nav className="-mb-[1px] flex flex-wrap gap-2 overflow-x-auto">
+                {[
+                  { key: "publications", label: "ผลงานตีพิมพ์ (Publications)" },
+                  { key: "innovations", label: "นวัตกรรม (Innovations)" },
+                ].map((tab) => {
+                  const isActive = tab.key === activeTab;
+                  return (
+                    <button
+                      key={tab.key}
+                      type="button"
+                      onClick={() => setActiveTab(tab.key)}
+                      className={`whitespace-nowrap rounded-t-md border-b-2 px-4 py-2 text-sm font-medium transition-colors ${
+                        isActive
+                          ? "border-blue-600 bg-white text-blue-600"
+                          : "border-transparent text-gray-500 hover:border-blue-200 hover:text-blue-600"
+                      }`}
+                    >
+                      {tab.label}
+                    </button>
+                  );
+                })}
+              </nav>
             </div>
-            <div className="overflow-x-auto">
-              {pubLoading ? (
-                <div className="space-y-2 animate-pulse">
-                  {[...Array(5)].map((_, i) => (
-                    <div key={i} className="h-6 rounded bg-gray-100" />
-                  ))}
-                </div>
-              ) : sortedPublications.length === 0 ? (
-                <p className="py-6 text-center text-gray-500">
-                  ยังไม่มีผลงานตีพิมพ์
-                </p>
-              ) : (
-                <>
-                  <table className="min-w-full divide-y divide-gray-200 text-sm">
-                    <thead className="bg-gray-50">
-                      <tr>
-                        <th
-                          className="cursor-pointer px-4 py-2 text-left font-medium text-gray-700"
-                          onClick={() => handleSort("title")}
-                        >
-                          ชื่อเรื่อง
-                          {sortField === "title" ? (
-                            sortDirection === "asc" ? (
-                              <ArrowUp className="ml-1 inline" size={14} />
-                            ) : (
-                              <ArrowDown className="ml-1 inline" size={14} />
-                            )
-                          ) : (
-                            <ArrowUpDown
-                              className="ml-1 inline text-gray-400"
-                              size={14}
-                            />
-                          )}
-                        </th>
-                        <th
-                          className="w-24 cursor-pointer px-4 py-2 text-right font-medium text-gray-700"
-                          onClick={() => handleSort("cited_by")}
-                        >
-                          อ้างโดย
-                          {sortField === "cited_by" ? (
-                            sortDirection === "asc" ? (
-                              <ArrowUp className="ml-1 inline" size={14} />
-                            ) : (
-                              <ArrowDown className="ml-1 inline" size={14} />
-                            )
-                          ) : (
-                            <ArrowUpDown
-                              className="ml-1 inline text-gray-400"
-                              size={14}
-                            />
-                          )}
-                        </th>
-                        <th
-                          className="w-20 cursor-pointer px-4 py-2 text-center font-medium text-gray-700"
-                          onClick={() => handleSort("year")}
-                        >
-                          ปี
-                          {sortField === "year" ? (
-                            sortDirection === "asc" ? (
-                              <ArrowUp className="ml-1 inline" size={14} />
-                            ) : (
-                              <ArrowDown className="ml-1 inline" size={14} />
-                            )
-                          ) : (
-                            <ArrowUpDown
-                              className="ml-1 inline text-gray-400"
-                              size={14}
-                            />
-                          )}
-                        </th>
-                      </tr>
-                    </thead>
-                    <tbody className="divide-y divide-gray-200">
-                      {paginatedPublications.map((pub) => (
-                        <tr key={pub.id} className="hover:bg-gray-50">
-                          <td className="max-w-xs px-4 py-2 lg:max-w-md">
-                            {pub.url ? (
-                              <a
-                                href={pub.url}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="block truncate text-blue-600 hover:underline"
-                                title={pub.title}
-                              >
-                                {pub.title}
-                              </a>
-                            ) : (
-                              <span className="block truncate" title={pub.title}>
-                                {pub.title}
-                              </span>
-                            )}
-                          </td>
-                          <td className="px-4 py-2 text-right">
-                            {pub.cited_by ? (
-                              pub.cited_by_url ? (
-                                <a
-                                  href={pub.cited_by_url}
-                                  target="_blank"
-                                  rel="noopener noreferrer"
-                                  className="text-blue-600 hover:underline"
-                                >
-                                  {pub.cited_by}
-                                </a>
-                              ) : (
-                                <span>{pub.cited_by}</span>
-                              )
-                            ) : (
-                              <span>-</span>
-                            )}
-                          </td>
-                          <td className="px-4 py-2 text-center">
-                            {pub.publication_year || "-"}
-                          </td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                  <div className="mt-4 flex items-center justify-between text-sm">
-                    <span className="text-gray-600">
-                      แสดง {(currentPage - 1) * rowsPerPage + 1}-
-                      {Math.min(
-                        currentPage * rowsPerPage,
-                        sortedPublications.length,
-                      )} จาก {sortedPublications.length}
-                    </span>
-                    <div className="space-x-2">
-                      <button
-                        onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
-                        disabled={currentPage === 1}
-                        className="rounded border px-3 py-1 disabled:opacity-50"
-                      >
-                        ก่อนหน้า
-                      </button>
-                      <button
-                        onClick={() =>
-                          setCurrentPage((p) => Math.min(totalPages, p + 1))
-                        }
-                        disabled={currentPage === totalPages}
-                        className="rounded border px-3 py-1 disabled:opacity-50"
-                      >
-                        ถัดไป
-                      </button>
-                    </div>
-                  </div>
-                </>
-              )}
-            </div>
-            <ScholarCitationsCard
-              loading={pubLoading}
-              metrics={citationMetrics}
-              formatNumber={formatNumber}
-            />
-          </section>
 
-          <section className="rounded-2xl border border-gray-100 bg-white p-6 shadow-sm">
-            <div className="mb-4 flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-              <h2 className="text-xl font-semibold text-gray-900">
-                นวัตกรรม (Innovations)
-              </h2>
-              <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-4">
-                <input
-                  type="text"
-                  value={innovSearchTerm}
-                  onChange={(e) => {
-                    setInnovSearchTerm(e.target.value);
-                    setInnovPage(1);
-                  }}
-                  placeholder="ค้นหาชื่อเรื่อง..."
-                  className="w-full rounded-md border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 sm:w-64"
-                />
-                <div className="flex items-center gap-2 text-sm text-gray-600">
-                  <span>แสดง</span>
-                  <select
-                    value={innovRowsPerPage}
-                    onChange={(e) => {
-                      setInnovRowsPerPage(parseInt(e.target.value));
-                      setInnovPage(1);
-                    }}
-                    className="rounded-md border border-gray-300 px-2 py-2"
-                  >
-                    <option value={10}>10</option>
-                    <option value={20}>20</option>
-                  </select>
-                  <span>รายการ</span>
-                </div>
-              </div>
-            </div>
-            <div className="overflow-x-auto">
-              {innovLoading ? (
-                <div className="space-y-2 animate-pulse">
-                  {[...Array(5)].map((_, i) => (
-                    <div key={i} className="h-6 rounded bg-gray-100" />
-                  ))}
-                </div>
-              ) : sortedInnovations.length === 0 ? (
-                <p className="py-6 text-center text-gray-500">ยังไม่มีนวัตกรรม</p>
-              ) : (
-                <>
-                  <table className="min-w-full divide-y divide-gray-200 text-sm">
-                    <thead className="bg-gray-50">
-                      <tr>
-                        <th
-                          className="cursor-pointer px-4 py-2 text-left font-medium text-gray-700"
-                          onClick={() => handleInnovSort("title")}
-                        >
-                          ชื่อนวัตกรรม
-                          {innovSortField === "title" ? (
-                            innovSortDirection === "asc" ? (
-                              <ArrowUp className="ml-1 inline" size={14} />
-                            ) : (
-                              <ArrowDown className="ml-1 inline" size={14} />
-                            )
-                          ) : (
-                            <ArrowUpDown
-                              className="ml-1 inline text-gray-400"
-                              size={14}
-                            />
-                          )}
-                        </th>
-                        <th
-                          className="w-40 cursor-pointer px-4 py-2 text-left font-medium text-gray-700"
-                          onClick={() => handleInnovSort("innovation_type")}
-                        >
-                          ประเภท
-                          {innovSortField === "innovation_type" ? (
-                            innovSortDirection === "asc" ? (
-                              <ArrowUp className="ml-1 inline" size={14} />
-                            ) : (
-                              <ArrowDown className="ml-1 inline" size={14} />
-                            )
-                          ) : (
-                            <ArrowUpDown
-                              className="ml-1 inline text-gray-400"
-                              size={14}
-                            />
-                          )}
-                        </th>
-                        <th
-                          className="w-32 cursor-pointer px-4 py-2 text-center font-medium text-gray-700"
-                          onClick={() => handleInnovSort("registered_date")}
-                        >
-                          วันที่จดทะเบียน
-                          {innovSortField === "registered_date" ? (
-                            innovSortDirection === "asc" ? (
-                              <ArrowUp className="ml-1 inline" size={14} />
-                            ) : (
-                              <ArrowDown className="ml-1 inline" size={14} />
-                            )
-                          ) : (
-                            <ArrowUpDown
-                              className="ml-1 inline text-gray-400"
-                              size={14}
-                            />
-                          )}
-                        </th>
-                      </tr>
-                    </thead>
-                    <tbody className="divide-y divide-gray-200">
-                      {paginatedInnovations.map((inv) => (
-                        <tr key={inv.id} className="hover:bg-gray-50">
-                          <td className="max-w-xs px-4 py-2 lg:max-w-md">
-                            <span className="block truncate" title={inv.title}>
-                              {inv.title}
-                            </span>
-                          </td>
-                          <td className="px-4 py-2">
-                            <span className="block truncate" title={inv.innovation_type}>
-                              {inv.innovation_type || "-"}
-                            </span>
-                          </td>
-                          <td className="px-4 py-2 text-center">
-                            {formatThaiDate(inv.registered_date)}
-                          </td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                  <div className="mt-4 flex items-center justify-between text-sm">
-                    <span className="text-gray-600">
-                      แสดง {(innovPage - 1) * innovRowsPerPage + 1}-
-                      {Math.min(
-                        innovPage * innovRowsPerPage,
-                        sortedInnovations.length,
-                      )} จาก {sortedInnovations.length}
-                    </span>
-                    <div className="space-x-2">
-                      <button
-                        onClick={() => setInnovPage((p) => Math.max(1, p - 1))}
-                        disabled={innovPage === 1}
-                        className="rounded border px-3 py-1 disabled:opacity-50"
+            {activeTab === "publications" ? (
+              <div className="space-y-6">
+                <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+                  <h3 className="text-base font-semibold text-gray-900 lg:text-lg">
+                    รายการผลงานตีพิมพ์
+                  </h3>
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-end sm:gap-4">
+                    <input
+                      type="text"
+                      value={searchTerm}
+                      onChange={(e) => {
+                        setSearchTerm(e.target.value);
+                        setCurrentPage(1);
+                      }}
+                      placeholder="ค้นหาชื่อเรื่อง..."
+                      className="w-full rounded-md border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 sm:w-64"
+                    />
+                    <div className="flex items-center gap-2 text-sm text-gray-600">
+                      <span>แสดง</span>
+                      <select
+                        value={rowsPerPage}
+                        onChange={(e) => {
+                          setRowsPerPage(parseInt(e.target.value));
+                          setCurrentPage(1);
+                        }}
+                        className="rounded-md border border-gray-300 px-2 py-2"
                       >
-                        ก่อนหน้า
-                      </button>
-                      <button
-                        onClick={() =>
-                          setInnovPage((p) => Math.min(innovTotalPages, p + 1))
-                        }
-                        disabled={innovPage === innovTotalPages}
-                        className="rounded border px-3 py-1 disabled:opacity-50"
-                      >
-                        ถัดไป
-                      </button>
+                        <option value={10}>10</option>
+                        <option value={20}>20</option>
+                      </select>
+                      <span>รายการ</span>
                     </div>
                   </div>
-                </>
-              )}
-            </div>
+                </div>
+                <div className="overflow-x-auto">
+                  {pubLoading ? (
+                    <div className="space-y-2 animate-pulse">
+                      {[...Array(5)].map((_, i) => (
+                        <div key={i} className="h-6 rounded bg-gray-100" />
+                      ))}
+                    </div>
+                  ) : sortedPublications.length === 0 ? (
+                    <p className="py-6 text-center text-gray-500">
+                      ยังไม่มีผลงานตีพิมพ์
+                    </p>
+                  ) : (
+                    <>
+                      <table className="min-w-full divide-y divide-gray-200 text-sm">
+                        <thead className="bg-gray-50">
+                          <tr>
+                            <th
+                              className="cursor-pointer px-4 py-2 text-left font-medium text-gray-700"
+                              onClick={() => handleSort("title")}
+                            >
+                              ชื่อเรื่อง
+                              {sortField === "title" ? (
+                                sortDirection === "asc" ? (
+                                  <ArrowUp className="ml-1 inline" size={14} />
+                                ) : (
+                                  <ArrowDown className="ml-1 inline" size={14} />
+                                )
+                              ) : (
+                                <ArrowUpDown
+                                  className="ml-1 inline text-gray-400"
+                                  size={14}
+                                />
+                              )}
+                            </th>
+                            <th
+                              className="w-24 cursor-pointer px-4 py-2 text-right font-medium text-gray-700"
+                              onClick={() => handleSort("cited_by")}
+                            >
+                              อ้างโดย
+                              {sortField === "cited_by" ? (
+                                sortDirection === "asc" ? (
+                                  <ArrowUp className="ml-1 inline" size={14} />
+                                ) : (
+                                  <ArrowDown className="ml-1 inline" size={14} />
+                                )
+                              ) : (
+                                <ArrowUpDown
+                                  className="ml-1 inline text-gray-400"
+                                  size={14}
+                                />
+                              )}
+                            </th>
+                            <th
+                              className="w-20 cursor-pointer px-4 py-2 text-center font-medium text-gray-700"
+                              onClick={() => handleSort("year")}
+                            >
+                              ปี
+                              {sortField === "year" ? (
+                                sortDirection === "asc" ? (
+                                  <ArrowUp className="ml-1 inline" size={14} />
+                                ) : (
+                                  <ArrowDown className="ml-1 inline" size={14} />
+                                )
+                              ) : (
+                                <ArrowUpDown
+                                  className="ml-1 inline text-gray-400"
+                                  size={14}
+                                />
+                              )}
+                            </th>
+                          </tr>
+                        </thead>
+                        <tbody className="divide-y divide-gray-200">
+                          {paginatedPublications.map((pub) => (
+                            <tr key={pub.id} className="hover:bg-gray-50">
+                              <td className="max-w-xs px-4 py-2 lg:max-w-md">
+                                {pub.url ? (
+                                  <a
+                                    href={pub.url}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="block truncate text-blue-600 hover:underline"
+                                    title={pub.title}
+                                  >
+                                    {pub.title}
+                                  </a>
+                                ) : (
+                                  <span className="block truncate" title={pub.title}>
+                                    {pub.title}
+                                  </span>
+                                )}
+                              </td>
+                              <td className="px-4 py-2 text-right">
+                                {pub.cited_by ? (
+                                  pub.cited_by_url ? (
+                                    <a
+                                      href={pub.cited_by_url}
+                                      target="_blank"
+                                      rel="noopener noreferrer"
+                                      className="text-blue-600 hover:underline"
+                                    >
+                                      {pub.cited_by}
+                                    </a>
+                                  ) : (
+                                    <span>{pub.cited_by}</span>
+                                  )
+                                ) : (
+                                  <span>-</span>
+                                )}
+                              </td>
+                              <td className="px-4 py-2 text-center">
+                                {pub.publication_year || "-"}
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                      <div className="mt-4 flex items-center justify-between text-sm">
+                        <span className="text-gray-600">
+                          แสดง {(currentPage - 1) * rowsPerPage + 1}-
+                          {Math.min(
+                            currentPage * rowsPerPage,
+                            sortedPublications.length,
+                          )} จาก {sortedPublications.length}
+                        </span>
+                        <div className="space-x-2">
+                          <button
+                            onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
+                            disabled={currentPage === 1}
+                            className="rounded border px-3 py-1 disabled:opacity-50"
+                          >
+                            ก่อนหน้า
+                          </button>
+                          <button
+                            onClick={() =>
+                              setCurrentPage((p) => Math.min(totalPages, p + 1))
+                            }
+                            disabled={currentPage === totalPages}
+                            className="rounded border px-3 py-1 disabled:opacity-50"
+                          >
+                            ถัดไป
+                          </button>
+                        </div>
+                      </div>
+                    </>
+                  )}
+                </div>
+                <ScholarCitationsCard
+                  loading={pubLoading}
+                  metrics={citationMetrics}
+                  formatNumber={formatNumber}
+                />
+              </div>
+            ) : (
+              <div className="space-y-6">
+                <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+                  <h3 className="text-base font-semibold text-gray-900 lg:text-lg">
+                    รายการนวัตกรรม
+                  </h3>
+                  <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-end sm:gap-4">
+                    <input
+                      type="text"
+                      value={innovSearchTerm}
+                      onChange={(e) => {
+                        setInnovSearchTerm(e.target.value);
+                        setInnovPage(1);
+                      }}
+                      placeholder="ค้นหาชื่อเรื่อง..."
+                      className="w-full rounded-md border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500 sm:w-64"
+                    />
+                    <div className="flex items-center gap-2 text-sm text-gray-600">
+                      <span>แสดง</span>
+                      <select
+                        value={innovRowsPerPage}
+                        onChange={(e) => {
+                          setInnovRowsPerPage(parseInt(e.target.value));
+                          setInnovPage(1);
+                        }}
+                        className="rounded-md border border-gray-300 px-2 py-2"
+                      >
+                        <option value={10}>10</option>
+                        <option value={20}>20</option>
+                      </select>
+                      <span>รายการ</span>
+                    </div>
+                  </div>
+                </div>
+                <div className="overflow-x-auto">
+                  {innovLoading ? (
+                    <div className="space-y-2 animate-pulse">
+                      {[...Array(5)].map((_, i) => (
+                        <div key={i} className="h-6 rounded bg-gray-100" />
+                      ))}
+                    </div>
+                  ) : sortedInnovations.length === 0 ? (
+                    <p className="py-6 text-center text-gray-500">ยังไม่มีนวัตกรรม</p>
+                  ) : (
+                    <>
+                      <table className="min-w-full divide-y divide-gray-200 text-sm">
+                        <thead className="bg-gray-50">
+                          <tr>
+                            <th
+                              className="cursor-pointer px-4 py-2 text-left font-medium text-gray-700"
+                              onClick={() => handleInnovSort("title")}
+                            >
+                              ชื่อนวัตกรรม
+                              {innovSortField === "title" ? (
+                                innovSortDirection === "asc" ? (
+                                  <ArrowUp className="ml-1 inline" size={14} />
+                                ) : (
+                                  <ArrowDown className="ml-1 inline" size={14} />
+                                )
+                              ) : (
+                                <ArrowUpDown
+                                  className="ml-1 inline text-gray-400"
+                                  size={14}
+                                />
+                              )}
+                            </th>
+                            <th
+                              className="w-40 cursor-pointer px-4 py-2 text-left font-medium text-gray-700"
+                              onClick={() => handleInnovSort("innovation_type")}
+                            >
+                              ประเภท
+                              {innovSortField === "innovation_type" ? (
+                                innovSortDirection === "asc" ? (
+                                  <ArrowUp className="ml-1 inline" size={14} />
+                                ) : (
+                                  <ArrowDown className="ml-1 inline" size={14} />
+                                )
+                              ) : (
+                                <ArrowUpDown
+                                  className="ml-1 inline text-gray-400"
+                                  size={14}
+                                />
+                              )}
+                            </th>
+                            <th
+                              className="w-32 cursor-pointer px-4 py-2 text-center font-medium text-gray-700"
+                              onClick={() => handleInnovSort("registered_date")}
+                            >
+                              วันที่จดทะเบียน
+                              {innovSortField === "registered_date" ? (
+                                innovSortDirection === "asc" ? (
+                                  <ArrowUp className="ml-1 inline" size={14} />
+                                ) : (
+                                  <ArrowDown className="ml-1 inline" size={14} />
+                                )
+                              ) : (
+                                <ArrowUpDown
+                                  className="ml-1 inline text-gray-400"
+                                  size={14}
+                                />
+                              )}
+                            </th>
+                          </tr>
+                        </thead>
+                        <tbody className="divide-y divide-gray-200">
+                          {paginatedInnovations.map((inv) => (
+                            <tr key={inv.id} className="hover:bg-gray-50">
+                              <td className="max-w-xs px-4 py-2 lg:max-w-md">
+                                <span className="block truncate" title={inv.title}>
+                                  {inv.title}
+                                </span>
+                              </td>
+                              <td className="px-4 py-2">
+                                <span className="block truncate" title={inv.innovation_type}>
+                                  {inv.innovation_type || "-"}
+                                </span>
+                              </td>
+                              <td className="px-4 py-2 text-center">
+                                {formatThaiDate(inv.registered_date)}
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                      <div className="mt-4 flex items-center justify-between text-sm">
+                        <span className="text-gray-600">
+                          แสดง {(innovPage - 1) * innovRowsPerPage + 1}-
+                          {Math.min(
+                            innovPage * innovRowsPerPage,
+                            sortedInnovations.length,
+                          )} จาก {sortedInnovations.length}
+                        </span>
+                        <div className="space-x-2">
+                          <button
+                            onClick={() => setInnovPage((p) => Math.max(1, p - 1))}
+                            disabled={innovPage === 1}
+                            className="rounded border px-3 py-1 disabled:opacity-50"
+                          >
+                            ก่อนหน้า
+                          </button>
+                          <button
+                            onClick={() =>
+                              setInnovPage((p) => Math.min(innovTotalPages, p + 1))
+                            }
+                            disabled={innovPage === innovTotalPages}
+                            className="rounded border px-3 py-1 disabled:opacity-50"
+                          >
+                            ถัดไป
+                          </button>
+                        </div>
+                      </div>
+                    </>
+                  )}
+                </div>
+              </div>
+            )}
           </section>
 
           <section className="rounded-2xl border border-gray-100 bg-white p-6 shadow-sm">


### PR DESCRIPTION
## Summary
- add a Scholar-styled citations widget below the publications list showing totals, h-index, i10, and a per-year bar strip
- derive metrics from existing publication fields, including citation histories when present and a publications-per-year fallback when histories are absent

## Testing
- npm run lint *(fails: command prompts for interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68cbf9aa1614832ab4478039da150650