### PR TITLE
Integrate user fund eligibility across API and UI

### DIFF
--- a/frontend_project_fund/app/staff/components/funds/ResearchFundContent.js
+++ b/frontend_project_fund/app/staff/components/funds/ResearchFundContent.js
@@ -43,6 +43,41 @@ export default function ResearchFundContent({ onNavigate }) {
     applyFilters();
   }, [searchTerm, statusFilter, fundCategories]);
 
+  const hasBudgetAvailable = (fund) => {
+    if (!fund) return false;
+    const budget = typeof fund.remaining_budget === 'number' ? fund.remaining_budget : 0;
+    const grant = fund.remaining_grant;
+    const grantAvailable = grant === null || grant === undefined || grant > 0;
+    return budget > 0 && grantAvailable;
+  };
+
+  const canUserApply = (fund) => {
+    if (!fund) return true;
+    if (fund.user_can_apply === false) return false;
+    if (fund.user_eligibility && fund.user_eligibility.can_apply === false) return false;
+    return true;
+  };
+
+  const isFundAvailableForUser = (fund) => hasBudgetAvailable(fund) && canUserApply(fund);
+
+  const formatApplications = (value) => {
+    if (value === null || value === undefined) {
+      return 'ไม่จำกัดครั้ง';
+    }
+    const numeric = Number(value);
+    if (Number.isNaN(numeric)) {
+      return 'ไม่ระบุ';
+    }
+    return `${new Intl.NumberFormat('th-TH').format(numeric)} ครั้ง`;
+  };
+
+  const formatPersonalQuota = (value) => {
+    if (value === null || value === undefined) {
+      return 'ไม่จำกัด';
+    }
+    return formatAmount(value);
+  };
+
   // useEffect สำหรับ modal focus และ ESC key
   useEffect(() => {
     const handleEscKey = (event) => {
@@ -166,8 +201,7 @@ export default function ResearchFundContent({ onNavigate }) {
       filtered = filtered.map(category => ({
         ...category,
         subcategories: category.subcategories?.filter(sub => {
-          const isAvailable = sub.remaining_budget > 0 && 
-                            (sub.remaining_grant === null || sub.remaining_grant === undefined || sub.remaining_grant > 0);
+          const isAvailable = isFundAvailableForUser(sub);
           return statusFilter === "available" ? isAvailable : !isAvailable;
         }) || []
       })).filter(category => category.subcategories && category.subcategories.length > 0);
@@ -231,7 +265,7 @@ export default function ResearchFundContent({ onNavigate }) {
     );
   }
 
-  const renderFundRow = (fund, category, isAvailable) => {
+  const renderFundRow = (fund, category) => {
     // ตรวจสอบทั้ง subcategorie_name และ subcategory_name
     const fundName = fund.subcategorie_name || fund.subcategory_name || 'ไม่ระบุชื่อทุน';
     const fundId = fund.subcategorie_id || fund.subcategory_id;
@@ -240,6 +274,25 @@ export default function ResearchFundContent({ onNavigate }) {
     const formConfig = FORM_TYPE_CONFIG[fund.form_type] || FORM_TYPE_CONFIG['download'];
     const buttonText = formConfig.buttonText;
     const ButtonIcon = formConfig.buttonIcon === 'FileText' ? FileText : Download;
+
+    const userEligibility = fund.user_eligibility || null;
+    const userCanApply = canUserApply(fund);
+    const budgetAvailable = hasBudgetAvailable(fund);
+    const isAvailable = budgetAvailable && userCanApply;
+
+    const restrictionMessage = (() => {
+      if (!userEligibility) return null;
+      if (userEligibility.is_eligible_flag === false) {
+        return userEligibility.restriction_reason || 'ไม่ได้รับสิทธิ์ในทุนนี้';
+      }
+      if (userEligibility.has_quota === false) {
+        return 'ใช้วงเงินส่วนบุคคลครบแล้ว';
+      }
+      if (userEligibility.has_applications === false) {
+        return 'ใช้จำนวนสิทธิ์ครบแล้ว';
+      }
+      return userEligibility.restriction_reason || null;
+    })();
 
     return (
       <tr key={fundId} className={!isAvailable ? 'bg-gray-50' : ''}>
@@ -279,12 +332,62 @@ export default function ResearchFundContent({ onNavigate }) {
                 สูงสุด/ทุน: {formatAmount(maxAmountPerGrant)}
               </div>
             )}
+            {!budgetAvailable && (
+              <div className="text-xs text-red-600 mt-1">
+                งบประมาณหมด
+              </div>
+            )}
+            {budgetAvailable && !userCanApply && (
+              <div className="text-xs text-red-600 mt-1">
+                สิทธิ์ของคุณไม่เพียงพอ
+              </div>
+            )}
+            {userEligibility && (
+              <div className="mt-3 pt-3 border-t border-gray-100 space-y-1">
+                <div className={`text-xs font-medium ${userCanApply ? 'text-indigo-600' : 'text-red-600'}`}>
+                  สิทธิ์ของฉัน: {userCanApply ? 'สามารถยื่นขอได้' : 'ไม่สามารถยื่นขอได้'}
+                </div>
+                {userEligibility.remaining_quota !== undefined && userEligibility.remaining_quota !== null && (
+                  <div className="text-xs text-gray-600">
+                    วงเงินส่วนบุคคลคงเหลือ: {formatPersonalQuota(userEligibility.remaining_quota)}
+                  </div>
+                )}
+                {userEligibility.remaining_quota === null && (
+                  <div className="text-xs text-gray-600">
+                    วงเงินส่วนบุคคลคงเหลือ: ไม่จำกัด
+                  </div>
+                )}
+                {userEligibility.remaining_applications !== undefined && userEligibility.remaining_applications !== null && (
+                  <div className="text-xs text-gray-600">
+                    สิทธิ์ยื่นขอคงเหลือ: {formatApplications(userEligibility.remaining_applications)}
+                  </div>
+                )}
+                {userEligibility.remaining_applications === null && (
+                  <div className="text-xs text-gray-600">
+                    สิทธิ์ยื่นขอคงเหลือ: ไม่จำกัดครั้ง
+                  </div>
+                )}
+                {userEligibility.max_allowed_amount !== undefined && userEligibility.max_allowed_amount !== null && (
+                  <div className="text-xs text-gray-500">
+                    จำกัดไม่เกิน: {formatAmount(userEligibility.max_allowed_amount)}
+                  </div>
+                )}
+                {!userCanApply && restrictionMessage && (
+                  <div className="text-xs text-red-600">
+                    {restrictionMessage}
+                  </div>
+                )}
+              </div>
+            )}
           </div>
         </td>
         <td className="px-6 py-4 text-center">
           <button
             onClick={() => handleViewForm(fund)}
-            className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-blue-600 hover:text-blue-700"
+            className={`inline-flex items-center gap-2 px-4 py-2 text-sm font-medium ${
+              isAvailable ? 'text-blue-600 hover:text-blue-700' : 'text-gray-400 cursor-not-allowed'
+            }`}
+            disabled={!isAvailable}
           >
             <ButtonIcon size={16} />
             {buttonText}
@@ -382,9 +485,7 @@ export default function ResearchFundContent({ onNavigate }) {
                   // ถ้ามี subcategories ให้แสดงแต่ละรายการ
                   if (category.subcategories && category.subcategories.length > 0) {
                     return category.subcategories.map((fund) => {
-                      const isAvailable = fund.remaining_budget > 0 && 
-                                        (fund.remaining_grant === null || fund.remaining_grant === undefined || fund.remaining_grant > 0);
-                      return renderFundRow(fund, category, isAvailable);
+                      return renderFundRow(fund, category);
                     });
                   } else {
                     // ถ้าไม่มี subcategories แสดงแถวว่างพร้อมข้อความ

--- a/frontend_project_fund/app/teacher/components/funds/ResearchFundContent.js
+++ b/frontend_project_fund/app/teacher/components/funds/ResearchFundContent.js
@@ -45,6 +45,41 @@ export default function ResearchFundContent({ onNavigate }) {
     applyFilters();
   }, [searchTerm, statusFilter, fundCategories]);
 
+  const hasBudgetAvailable = (fund) => {
+    if (!fund) return false;
+    const budget = typeof fund.remaining_budget === 'number' ? fund.remaining_budget : 0;
+    const grant = fund.remaining_grant;
+    const grantAvailable = grant === null || grant === undefined || grant > 0;
+    return budget > 0 && grantAvailable;
+  };
+
+  const canUserApply = (fund) => {
+    if (!fund) return true;
+    if (fund.user_can_apply === false) return false;
+    if (fund.user_eligibility && fund.user_eligibility.can_apply === false) return false;
+    return true;
+  };
+
+  const isFundAvailableForUser = (fund) => hasBudgetAvailable(fund) && canUserApply(fund);
+
+  const formatApplications = (value) => {
+    if (value === null || value === undefined) {
+      return 'ไม่จำกัดครั้ง';
+    }
+    const numeric = Number(value);
+    if (Number.isNaN(numeric)) {
+      return 'ไม่ระบุ';
+    }
+    return `${new Intl.NumberFormat('th-TH').format(numeric)} ครั้ง`;
+  };
+
+  const formatPersonalQuota = (value) => {
+    if (value === null || value === undefined) {
+      return 'ไม่จำกัด';
+    }
+    return formatAmount(value);
+  };
+
   // useEffect สำหรับ modal focus และ ESC key
   useEffect(() => {
     const handleEscKey = (event) => {
@@ -175,8 +210,7 @@ export default function ResearchFundContent({ onNavigate }) {
       filtered = filtered.map(category => ({
         ...category,
         subcategories: category.subcategories?.filter(sub => {
-          const isAvailable = sub.remaining_budget > 0 && 
-                            (sub.remaining_grant === null || sub.remaining_grant === undefined || sub.remaining_grant > 0);
+          const isAvailable = isFundAvailableForUser(sub);
           return statusFilter === "available" ? isAvailable : !isAvailable;
         }) || []
       })).filter(category => category.subcategories && category.subcategories.length > 0);
@@ -239,15 +273,32 @@ export default function ResearchFundContent({ onNavigate }) {
     );
   }
 
-  const renderFundRow = (fund, category, isAvailable) => {
+  const renderFundRow = (fund, category) => {
     // ตรวจสอบทั้ง subcategorie_name และ subcategory_name
     const fundName = fund.subcategorie_name || fund.subcategory_name || 'ไม่ระบุชื่อทุน';
     const fundId = fund.subcategorie_id || fund.subcategory_id;
     const hasOnlineForm = fund.has_online_form === true;
     const maxAmountPerGrant = fund.max_amount_per_grant || fund.allocated_amount;
-    // const formConfig = FORM_TYPE_CONFIG[fund.form_type] || FORM_TYPE_CONFIG['download'];
-    // const buttonText = formConfig.buttonText;
-    // const ButtonIcon = formConfig.buttonIcon === 'FileText' ? FileText : Download;
+
+    const userEligibility = fund.user_eligibility || null;
+    const userCanApply = canUserApply(fund);
+    const budgetAvailable = hasBudgetAvailable(fund);
+    const isAvailable = budgetAvailable && userCanApply;
+
+    const restrictionMessage = (() => {
+      if (!userEligibility) return null;
+      if (userEligibility.is_eligible_flag === false) {
+        return userEligibility.restriction_reason || 'ไม่ได้รับสิทธิ์ในทุนนี้';
+      }
+      if (userEligibility.has_quota === false) {
+        return 'ใช้วงเงินส่วนบุคคลครบแล้ว';
+      }
+      if (userEligibility.has_applications === false) {
+        return 'ใช้จำนวนสิทธิ์ครบแล้ว';
+      }
+      return userEligibility.restriction_reason || null;
+    })();
+
     const buttonText = 'ยื่นขอทุน';
     const ButtonIcon = FileText;
 
@@ -289,9 +340,51 @@ export default function ResearchFundContent({ onNavigate }) {
                 สูงสุด/ทุน: {formatAmount(maxAmountPerGrant)}
               </div>
             )}
-            {!isAvailable && (
+            {!budgetAvailable && (
               <div className="text-xs text-red-600 mt-1">
                 งบประมาณหมด
+              </div>
+            )}
+            {budgetAvailable && !userCanApply && (
+              <div className="text-xs text-red-600 mt-1">
+                สิทธิ์ของคุณไม่เพียงพอ
+              </div>
+            )}
+            {userEligibility && (
+              <div className="mt-3 pt-3 border-t border-gray-100 space-y-1">
+                <div className={`text-xs font-medium ${userCanApply ? 'text-indigo-600' : 'text-red-600'}`}>
+                  สิทธิ์ของฉัน: {userCanApply ? 'สามารถยื่นขอได้' : 'ไม่สามารถยื่นขอได้'}
+                </div>
+                {userEligibility.remaining_quota !== undefined && userEligibility.remaining_quota !== null && (
+                  <div className="text-xs text-gray-600">
+                    วงเงินส่วนบุคคลคงเหลือ: {formatPersonalQuota(userEligibility.remaining_quota)}
+                  </div>
+                )}
+                {userEligibility.remaining_quota === null && (
+                  <div className="text-xs text-gray-600">
+                    วงเงินส่วนบุคคลคงเหลือ: ไม่จำกัด
+                  </div>
+                )}
+                {userEligibility.remaining_applications !== undefined && userEligibility.remaining_applications !== null && (
+                  <div className="text-xs text-gray-600">
+                    สิทธิ์ยื่นขอคงเหลือ: {formatApplications(userEligibility.remaining_applications)}
+                  </div>
+                )}
+                {userEligibility.remaining_applications === null && (
+                  <div className="text-xs text-gray-600">
+                    สิทธิ์ยื่นขอคงเหลือ: ไม่จำกัดครั้ง
+                  </div>
+                )}
+                {userEligibility.max_allowed_amount !== undefined && userEligibility.max_allowed_amount !== null && (
+                  <div className="text-xs text-gray-500">
+                    จำกัดไม่เกิน: {formatAmount(userEligibility.max_allowed_amount)}
+                  </div>
+                )}
+                {!userCanApply && restrictionMessage && (
+                  <div className="text-xs text-red-600">
+                    {restrictionMessage}
+                  </div>
+                )}
               </div>
             )}
           </div>
@@ -443,9 +536,7 @@ export default function ResearchFundContent({ onNavigate }) {
                   // ถ้ามี subcategories ให้แสดงแต่ละรายการ
                   if (category.subcategories && category.subcategories.length > 0) {
                     return category.subcategories.map((fund) => {
-                      const isAvailable = fund.remaining_budget > 0 && 
-                                        (fund.remaining_grant === null || fund.remaining_grant === undefined || fund.remaining_grant > 0);
-                      return renderFundRow(fund, category, isAvailable);
+                      return renderFundRow(fund, category);
                     });
                   } else {
                     // ถ้าไม่มี subcategories แสดงแถวว่างพร้อมข้อความ

--- a/fund-management-api/controllers/admin_submission.go
+++ b/fund-management-api/controllers/admin_submission.go
@@ -2,6 +2,7 @@
 package controllers
 
 import (
+	"errors"
 	"fund-management-api/config"
 	"fund-management-api/models"
 	"net/http"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
 )
 
 // ==============================
@@ -298,6 +300,8 @@ func ApproveSubmission(c *gin.Context) {
 		return
 	}
 
+	approvedAmount := 0.0
+
 	// Update detail for publication_reward
 	if submission.SubmissionType == "publication_reward" {
 		var detail models.PublicationRewardDetail
@@ -346,6 +350,52 @@ func ApproveSubmission(c *gin.Context) {
 				tx.Rollback()
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update detail"})
 				return
+			}
+		}
+
+		approvedAmount = detail.TotalApproveAmount
+	} else if submission.SubmissionType == "fund_application" {
+		var detail models.FundApplicationDetail
+		if submission.FundApplicationDetail != nil {
+			detail = *submission.FundApplicationDetail
+		} else {
+			if err := tx.Where("submission_id = ?", submissionID).First(&detail).Error; err != nil {
+				if !errors.Is(err, gorm.ErrRecordNotFound) {
+					tx.Rollback()
+					c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to load application detail"})
+					return
+				}
+			}
+		}
+
+		if detail.DetailID != 0 {
+			approvedAmount = detail.ApprovedAmount
+		}
+	}
+
+	// Deduct eligibility counters when applicable
+	if submission.UserID != 0 {
+		categoryIDPtr := submission.CategoryID
+		if categoryIDPtr == nil && submission.SubcategoryID != nil {
+			if catID, err := resolveCategoryIDFromSubcategory(tx, *submission.SubcategoryID); err == nil {
+				categoryIDPtr = &catID
+			}
+		}
+
+		if categoryIDPtr != nil {
+			eligibility, err := findUserFundEligibility(tx, submission.UserID, submission.YearID, categoryIDPtr, submission.SubcategoryID)
+			if err != nil {
+				if !errors.Is(err, gorm.ErrRecordNotFound) {
+					tx.Rollback()
+					c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to load eligibility record", "debug": err.Error()})
+					return
+				}
+			} else {
+				if err := consumeEligibilityOnApproval(tx, eligibility, approvedAmount, true); err != nil {
+					tx.Rollback()
+					c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update eligibility limits", "debug": err.Error()})
+					return
+				}
 			}
 		}
 	}

--- a/fund-management-api/controllers/application.go
+++ b/fund-management-api/controllers/application.go
@@ -3,14 +3,17 @@ package controllers
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"fund-management-api/config"
 	"fund-management-api/models"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
 )
 
 // Helper function to generate application number
@@ -166,13 +169,36 @@ func CreateApplication(c *gin.Context) {
 		return
 	}
 
+	userIDInt, ok := userID.(int)
+	if !ok {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Invalid user context"})
+		return
+	}
+
+	categoryID := subcategory.CategoryID
+	subcategoryID := req.SubcategoryID
+	eligibility, err := findUserFundEligibility(nil, userIDInt, req.YearID, &categoryID, &subcategoryID)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "No eligibility record found for this fund"})
+		} else {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to verify eligibility"})
+		}
+		return
+	}
+
+	if err := ensureEligibilityAllowsStart(eligibility, &req.RequestedAmount); err != nil {
+		c.JSON(http.StatusForbidden, gin.H{"error": err.Error(), "eligibility": eligibility})
+		return
+	}
+
 	// Generate application number
 	applicationNumber := generateApplicationNumber()
 
 	// Create application
 	now := time.Now()
 	application := models.FundApplication{
-		UserID:              userID.(int),
+		UserID:              userIDInt,
 		YearID:              req.YearID,
 		SubcategoryID:       req.SubcategoryID,
 		ApplicationStatusID: 1, // 1 = รอพิจารณา
@@ -354,6 +380,22 @@ func ApproveApplication(c *gin.Context) {
 		return
 	}
 
+	if catID, err := resolveCategoryIDFromSubcategory(nil, application.SubcategoryID); err == nil {
+		subID := application.SubcategoryID
+		eligibility, err := findUserFundEligibility(nil, application.UserID, application.YearID, &catID, &subID)
+		if err != nil {
+			if !errors.Is(err, gorm.ErrRecordNotFound) {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to load eligibility record", "debug": err.Error()})
+				return
+			}
+		} else {
+			if err := consumeEligibilityOnApproval(nil, eligibility, req.ApprovedAmount, true); err != nil {
+				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update eligibility limits", "debug": err.Error()})
+				return
+			}
+		}
+	}
+
 	c.JSON(http.StatusOK, gin.H{
 		"message":     "Application approved successfully",
 		"application": application,
@@ -502,48 +544,90 @@ func GetYears(c *gin.Context) {
 // GetTeacherSubcategories - Fixed SQL syntax for production server
 func GetTeacherSubcategories(c *gin.Context) {
 	categoryID := c.Query("category_id")
-	userID, _ := c.Get("userID")
-	roleID, _ := c.Get("roleID")
+	yearParam := c.Query("year_id")
+	userIDValue, _ := c.Get("userID")
+	roleIDValue, _ := c.Get("roleID")
+
+	userIDInt := 0
+	if uid, ok := userIDValue.(int); ok {
+		userIDInt = uid
+	}
+
+	roleID := 0
+	if rid, ok := roleIDValue.(int); ok {
+		roleID = rid
+	}
+
+	var yearFilter *int
+	if yearParam != "" {
+		if parsed, err := strconv.Atoi(yearParam); err == nil {
+			yearFilter = &parsed
+		}
+	}
 
 	// Debug log
 	fmt.Printf("\n=== GetTeacherSubcategories Debug ===\n")
 	fmt.Printf("categoryID: %s\n", categoryID)
-	fmt.Printf("userID: %v\n", userID)
+	fmt.Printf("userID: %v\n", userIDInt)
 	fmt.Printf("roleID: %v\n", roleID)
+	if yearFilter != nil {
+		fmt.Printf("yearID: %d\n", *yearFilter)
+	}
 
 	var results []map[string]interface{}
 
 	// Build base query - เพิ่ม form_type, form_url ใน SELECT
 	baseQuery := `
-		SELECT DISTINCT
-			fs.subcategory_id,
-			fs.subcategory_name,
-			fs.category_id,
-			fs.status,
-			fs.fund_condition,
-			fs.target_roles,
-			fs.form_type,              -- เพิ่มฟิลด์ใหม่
-			fs.form_url,               -- เพิ่มฟิลด์ใหม่
-			fs.comment as sub_comment,
-			sb.subcategory_budget_id,
-			sb.allocated_amount,
-			sb.used_amount,
-			sb.remaining_budget,
-			sb.max_grants,
-			sb.max_amount_per_grant,
-			sb.remaining_grant,
-			sb.level,
-			sb.fund_description,
-			sb.comment as budget_comment
-		FROM fund_subcategories fs
-		LEFT JOIN subcategory_budgets sb ON fs.subcategory_id = sb.subcategory_id
-			AND sb.delete_at IS NULL
-			AND sb.status = 'active'
-		WHERE fs.delete_at IS NULL 
-			AND fs.status = 'active'`
+                SELECT DISTINCT
+                        fs.subcategory_id,
+                        fs.subcategory_name,
+                        fs.category_id,
+                        fs.status,
+                        fs.fund_condition,
+                        fs.target_roles,
+                        fs.form_type,              -- เพิ่มฟิลด์ใหม่
+                        fs.form_url,               -- เพิ่มฟิลด์ใหม่
+                        fs.comment as sub_comment,
+                        sb.subcategory_budget_id,
+                        sb.allocated_amount,
+                        sb.used_amount,
+                        sb.remaining_budget,
+                        sb.max_grants,
+                        sb.max_amount_per_grant,
+                        sb.remaining_grant,
+                        sb.level,
+                        sb.fund_description,
+                        sb.comment as budget_comment,
+                        ufe.user_fund_eligibility_id,
+                        ufe.remaining_quota,
+                        ufe.max_allowed_amount,
+                        ufe.remaining_applications,
+                        ufe.is_eligible,
+                        ufe.restriction_reason,
+                        ufe.calculated_at,
+                        ufe.update_at
+                FROM fund_subcategories fs
+                LEFT JOIN subcategory_budgets sb ON fs.subcategory_id = sb.subcategory_id
+                        AND sb.delete_at IS NULL
+                        AND sb.status = 'active'
+                LEFT JOIN user_fund_eligibilities ufe ON fs.category_id = ufe.category_id
+                        AND ufe.user_id = ?
+                        AND ufe.delete_at IS NULL
+                        AND (ufe.subcategory_id IS NULL OR ufe.subcategory_id = fs.subcategory_id)`
+
+	if yearFilter != nil {
+		baseQuery += "\n                        AND ufe.year_id = ?"
+	}
+
+	baseQuery += `
+                WHERE fs.delete_at IS NULL
+                        AND fs.status = 'active'`
 
 	var conditions []string
-	var args []interface{}
+	args := []interface{}{userIDInt}
+	if yearFilter != nil {
+		args = append(args, *yearFilter)
+	}
 
 	// Add filters
 	if categoryID != "" {
@@ -552,8 +636,8 @@ func GetTeacherSubcategories(c *gin.Context) {
 	}
 
 	// Role-based filtering
-	roleIDStr := fmt.Sprintf("%d", roleID.(int))
-	if roleID.(int) != 3 { // Not admin
+	roleIDStr := fmt.Sprintf("%d", roleID)
+	if roleID != 3 { // Not admin
 		conditions = append(conditions, "(fs.target_roles IS NULL OR fs.target_roles = '' OR JSON_CONTAINS(fs.target_roles, ?))")
 		args = append(args, fmt.Sprintf(`"%s"`, roleIDStr))
 		fmt.Printf("Applied role filtering for role: %s\n", roleIDStr)
@@ -609,6 +693,14 @@ func GetTeacherSubcategories(c *gin.Context) {
 			level                *string
 			fundDescription      *string
 			budgetComment        *string
+			eligibilityID        *int
+			userQuota            *float64
+			userMaxAmount        *float64
+			userApplications     *int
+			userEligible         *string
+			userRestriction      *string
+			userCalculated       *time.Time
+			userUpdated          *time.Time
 		)
 
 		err := rows.Scan(
@@ -631,6 +723,14 @@ func GetTeacherSubcategories(c *gin.Context) {
 			&level,
 			&fundDescription,
 			&budgetComment,
+			&eligibilityID,
+			&userQuota,
+			&userMaxAmount,
+			&userApplications,
+			&userEligible,
+			&userRestriction,
+			&userCalculated,
+			&userUpdated,
 		)
 		if err != nil {
 			fmt.Printf("Scan error: %v\n", err)
@@ -657,6 +757,30 @@ func GetTeacherSubcategories(c *gin.Context) {
 			continue
 		}
 		processedIDs[uniqueID] = true
+
+		eligibilityExists := eligibilityID != nil
+		eligibleFlag := true
+		if eligibilityExists && userEligible != nil {
+			normalized := strings.TrimSpace(strings.ToLower(*userEligible))
+			if normalized == "no" || normalized == "false" || normalized == "0" {
+				eligibleFlag = false
+			}
+		}
+
+		hasQuota := true
+		if eligibilityExists && userQuota != nil {
+			hasQuota = *userQuota > 0
+		}
+
+		hasApplications := true
+		if eligibilityExists && userApplications != nil {
+			hasApplications = *userApplications > 0
+		}
+
+		userCanApply := true
+		if eligibilityExists {
+			userCanApply = eligibleFlag && hasQuota && hasApplications
+		}
 
 		// Create result object - เพิ่มฟิลด์ใหม่
 		result := map[string]interface{}{
@@ -721,6 +845,55 @@ func GetTeacherSubcategories(c *gin.Context) {
 			result["is_unlimited_grants"] = false
 		}
 
+		result["user_can_apply"] = userCanApply
+
+		if eligibilityExists {
+			var eligibilityIDVal interface{}
+			if eligibilityID != nil {
+				eligibilityIDVal = *eligibilityID
+			}
+
+			var remainingQuotaVal interface{}
+			if userQuota != nil {
+				remainingQuotaVal = *userQuota
+			}
+
+			var maxAllowedVal interface{}
+			if userMaxAmount != nil {
+				maxAllowedVal = *userMaxAmount
+			}
+
+			var remainingAppsVal interface{}
+			if userApplications != nil {
+				remainingAppsVal = *userApplications
+			}
+
+			var eligibleValue interface{}
+			if userEligible != nil {
+				eligibleValue = *userEligible
+			}
+
+			var restrictionVal interface{}
+			if userRestriction != nil {
+				restrictionVal = *userRestriction
+			}
+
+			result["user_eligibility"] = map[string]interface{}{
+				"user_fund_eligibility_id": eligibilityIDVal,
+				"remaining_quota":          remainingQuotaVal,
+				"max_allowed_amount":       maxAllowedVal,
+				"remaining_applications":   remainingAppsVal,
+				"is_eligible":              eligibleValue,
+				"restriction_reason":       restrictionVal,
+				"calculated_at":            userCalculated,
+				"updated_at":               userUpdated,
+				"has_quota":                hasQuota,
+				"has_applications":         hasApplications,
+				"is_eligible_flag":         eligibleFlag,
+				"can_apply":                userCanApply,
+			}
+		}
+
 		results = append(results, result)
 		fmt.Printf("Added fund: %s (ID: %s)\n", displayName, uniqueID)
 	}
@@ -742,7 +915,7 @@ func GetTeacherSubcategories(c *gin.Context) {
 		"success":       true,
 		"subcategories": results,
 		"role_id":       roleID,
-		"user_id":       userID,
+		"user_id":       userIDInt,
 		"total":         len(results),
 	})
 }

--- a/fund-management-api/controllers/eligibility_helpers.go
+++ b/fund-management-api/controllers/eligibility_helpers.go
@@ -1,0 +1,139 @@
+package controllers
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"fund-management-api/config"
+	"fund-management-api/models"
+
+	"gorm.io/gorm"
+)
+
+// findUserFundEligibility fetches the best matching eligibility row for a user/year/category/subcategory combination.
+// If a subcategory-specific record is not found it falls back to the category-level record (subcategory_id IS NULL).
+func findUserFundEligibility(tx *gorm.DB, userID, yearID int, categoryID *int, subcategoryID *int) (*models.UserFundEligibility, error) {
+	if tx == nil {
+		tx = config.DB
+	}
+
+	conditions := []string{"user_id = ?", "year_id = ?", "delete_at IS NULL"}
+	args := []interface{}{userID, yearID}
+
+	if categoryID != nil {
+		conditions = append(conditions, "category_id = ?")
+		args = append(args, *categoryID)
+	}
+
+	baseWhere := strings.Join(conditions, " AND ")
+
+	if subcategoryID != nil {
+		subArgs := append(args, *subcategoryID)
+		var eligibility models.UserFundEligibility
+		if err := tx.Where(baseWhere+" AND subcategory_id = ?", subArgs...).First(&eligibility).Error; err == nil {
+			return &eligibility, nil
+		} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, err
+		}
+	}
+
+	// Fallback to category level (subcategory_id is NULL/0)
+	fallbackWhere := baseWhere + " AND (subcategory_id IS NULL OR subcategory_id = 0)"
+	var eligibility models.UserFundEligibility
+	if err := tx.Where(fallbackWhere, args...).First(&eligibility).Error; err != nil {
+		return nil, err
+	}
+
+	return &eligibility, nil
+}
+
+// ensureEligibilityAllowsStart validates whether the user can start a submission/application based on the eligibility record.
+// If requiredAmount is nil the check will only ensure that some quota remains; otherwise it must cover the requested amount.
+func ensureEligibilityAllowsStart(eligibility *models.UserFundEligibility, requiredAmount *float64) error {
+	if eligibility == nil {
+		return fmt.Errorf("no eligibility record configured for this fund")
+	}
+
+	if !eligibility.EligibleFlag() {
+		if eligibility.RestrictionReason != nil && strings.TrimSpace(*eligibility.RestrictionReason) != "" {
+			return fmt.Errorf("user is not eligible for this fund: %s", strings.TrimSpace(*eligibility.RestrictionReason))
+		}
+		return fmt.Errorf("user is not eligible for this fund")
+	}
+
+	if !eligibility.HasRemainingApplications() {
+		return fmt.Errorf("no remaining application quota for this fund")
+	}
+
+	if requiredAmount != nil {
+		if eligibility.MaxAllowedAmount != nil && *requiredAmount > *eligibility.MaxAllowedAmount {
+			return fmt.Errorf("requested amount exceeds the maximum allowed for this fund")
+		}
+		if !eligibility.HasQuotaFor(*requiredAmount) {
+			return fmt.Errorf("requested amount exceeds your remaining quota")
+		}
+	} else if !eligibility.HasAnyQuota() {
+		return fmt.Errorf("no remaining quota for this fund")
+	}
+
+	return nil
+}
+
+// consumeEligibilityOnApproval deducts the approved amount and/or application counter from the eligibility record.
+func consumeEligibilityOnApproval(tx *gorm.DB, eligibility *models.UserFundEligibility, amount float64, decrementApplications bool) error {
+	if eligibility == nil {
+		return fmt.Errorf("eligibility record is required")
+	}
+	if tx == nil {
+		tx = config.DB
+	}
+
+	updates := map[string]interface{}{}
+
+	if eligibility.RemainingQuota != nil && amount > 0 {
+		newQuota := *eligibility.RemainingQuota - amount
+		if newQuota < 0 {
+			newQuota = 0
+		}
+		updates["remaining_quota"] = newQuota
+	}
+
+	if decrementApplications && eligibility.RemainingApplications != nil && *eligibility.RemainingApplications > 0 {
+		newApplications := *eligibility.RemainingApplications - 1
+		if newApplications < 0 {
+			newApplications = 0
+		}
+		updates["remaining_applications"] = newApplications
+	}
+
+	if len(updates) == 0 {
+		return nil
+	}
+
+	updates["update_at"] = time.Now()
+
+	return tx.Model(&models.UserFundEligibility{}).
+		Where("user_fund_eligibility_id = ?", eligibility.UserFundEligibilityID).
+		Updates(updates).Error
+}
+
+// resolveCategoryIDFromSubcategory finds the parent category for the given subcategory ID.
+func resolveCategoryIDFromSubcategory(tx *gorm.DB, subcategoryID int) (int, error) {
+	if tx == nil {
+		tx = config.DB
+	}
+
+	var categoryID int
+	if err := tx.Table("fund_subcategories").
+		Select("category_id").
+		Where("subcategory_id = ?", subcategoryID).
+		Scan(&categoryID).Error; err != nil {
+		return 0, err
+	}
+	if categoryID == 0 {
+		return 0, fmt.Errorf("unable to determine category for subcategory %d", subcategoryID)
+	}
+	return categoryID, nil
+}

--- a/fund-management-api/controllers/fund_api.go
+++ b/fund-management-api/controllers/fund_api.go
@@ -6,16 +6,43 @@ import (
 	"fmt"
 	"fund-management-api/config"
 	"net/http"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 )
 
 // GetFundStructure - API ใหม่ที่จัดกลุ่มข้อมูลให้พร้อมใช้งาน
 func GetFundStructure(c *gin.Context) {
-	yearID := c.Query("year_id")
+	yearIDParam := c.Query("year_id")
 	categoryID := c.Query("category_id")
-	userID, _ := c.Get("userID")
-	roleID, _ := c.Get("roleID")
+
+	userIDValue, _ := c.Get("userID")
+	roleIDValue, _ := c.Get("roleID")
+
+	userID := 0
+	if uid, ok := userIDValue.(int); ok {
+		userID = uid
+	}
+
+	roleID := 0
+	if rid, ok := roleIDValue.(int); ok {
+		roleID = rid
+	}
+
+	var yearFilter *int
+	if yearIDParam != "" {
+		if parsed, err := strconv.Atoi(yearIDParam); err == nil {
+			yearFilter = &parsed
+		}
+	}
+
+	filterParam := c.DefaultQuery("eligible_only", "")
+	if filterParam == "" {
+		filterParam = c.DefaultQuery("filter_ineligible", "")
+	}
+	filterIneligible := strings.EqualFold(filterParam, "true") || filterParam == "1" || strings.EqualFold(filterParam, "yes")
 
 	// Build query สำหรับดึง categories และ subcategories
 	categoriesQuery := `
@@ -30,9 +57,9 @@ func GetFundStructure(c *gin.Context) {
 
 	var categoryArgs []interface{}
 
-	if yearID != "" {
+	if yearIDParam != "" {
 		categoriesQuery += " AND fc.year_id = ?"
-		categoryArgs = append(categoryArgs, yearID)
+		categoryArgs = append(categoryArgs, yearIDParam)
 	}
 
 	if categoryID != "" {
@@ -59,16 +86,16 @@ func GetFundStructure(c *gin.Context) {
 			catID     int
 			catName   string
 			catStatus string
-			yearID    *int
+			catYearID *int
 		)
 
-		err := categoryRows.Scan(&catID, &catName, &catStatus, &yearID)
+		err := categoryRows.Scan(&catID, &catName, &catStatus, &catYearID)
 		if err != nil {
 			continue
 		}
 
 		// Get subcategories for this category (grouped)
-		subcategories := getGroupedSubcategories(catID, roleID.(int))
+		subcategories := getGroupedSubcategories(catID, roleID, userID, yearFilter, filterIneligible)
 
 		// Only add category if it has visible subcategories
 		if len(subcategories) > 0 {
@@ -76,7 +103,7 @@ func GetFundStructure(c *gin.Context) {
 				"category_id":   catID,
 				"category_name": catName,
 				"status":        catStatus,
-				"year_id":       yearID,
+				"year_id":       catYearID,
 				"subcategories": subcategories,
 			}
 			categories = append(categories, category)
@@ -84,20 +111,19 @@ func GetFundStructure(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{
-		"success":    true,
-		"categories": categories,
-		"total":      len(categories),
-		"user_id":    userID,
-		"role_id":    roleID,
+		"success":       true,
+		"categories":    categories,
+		"total":         len(categories),
+		"user_id":       userID,
+		"role_id":       roleID,
+		"eligible_only": filterIneligible,
 	})
 }
 
 // getGroupedSubcategories - Helper function to get subcategories grouped by subcategory_id
-func getGroupedSubcategories(categoryID int, roleID int) []map[string]interface{} {
-	// Query ที่ดึงข้อมูล subcategories และใช้ budget จากรายการแรกที่พบ (ไม่รวม)
-	// เพราะ budget ที่มี subcategory_id เดียวกันใช้เงินก้อนเดียวกัน
+func getGroupedSubcategories(categoryID int, roleID int, userID int, yearFilter *int, filterIneligible bool) []map[string]interface{} {
 	query := `
-        SELECT 
+        SELECT
             fs.subcategory_id,
             fs.subcategory_name,
             fs.fund_condition,
@@ -105,43 +131,64 @@ func getGroupedSubcategories(categoryID int, roleID int) []map[string]interface{
             fs.form_type,
             fs.form_url,
             fs.status,
-            -- ใช้ค่าแรกที่พบ ไม่ใช้ SUM เพราะเป็นเงินก้อนเดียวกัน
-            (SELECT sb1.allocated_amount 
-             FROM subcategory_budgets sb1 
-             WHERE sb1.subcategory_id = fs.subcategory_id 
-                AND sb1.delete_at IS NULL 
-                AND sb1.status = 'active' 
+            (SELECT sb1.allocated_amount
+             FROM subcategory_budgets sb1
+             WHERE sb1.subcategory_id = fs.subcategory_id
+                AND sb1.delete_at IS NULL
+                AND sb1.status = 'active'
              LIMIT 1) as allocated_amount,
-            (SELECT sb2.remaining_budget 
-             FROM subcategory_budgets sb2 
-             WHERE sb2.subcategory_id = fs.subcategory_id 
-                AND sb2.delete_at IS NULL 
-                AND sb2.status = 'active' 
+            (SELECT sb2.remaining_budget
+             FROM subcategory_budgets sb2
+             WHERE sb2.subcategory_id = fs.subcategory_id
+                AND sb2.delete_at IS NULL
+                AND sb2.status = 'active'
              LIMIT 1) as remaining_budget,
             COUNT(DISTINCT sb.subcategory_budget_id) as budget_count,
             GROUP_CONCAT(DISTINCT sb.level) as levels,
-            GROUP_CONCAT(DISTINCT sb.fund_description) as descriptions
+            GROUP_CONCAT(DISTINCT sb.fund_description) as descriptions,
+            ufe.user_fund_eligibility_id,
+            ufe.remaining_quota,
+            ufe.max_allowed_amount,
+            ufe.remaining_applications,
+            ufe.is_eligible,
+            ufe.restriction_reason,
+            ufe.calculated_at,
+            ufe.update_at
         FROM fund_subcategories fs
         LEFT JOIN subcategory_budgets sb ON fs.subcategory_id = sb.subcategory_id
             AND sb.delete_at IS NULL
             AND sb.status = 'active'
-        WHERE fs.delete_at IS NULL 
+        LEFT JOIN user_fund_eligibilities ufe ON ufe.category_id = fs.category_id
+            AND ufe.user_id = ?
+            AND ufe.delete_at IS NULL
+            AND (ufe.subcategory_id IS NULL OR ufe.subcategory_id = fs.subcategory_id)`
+
+	args := []interface{}{userID}
+	if yearFilter != nil {
+		query += " AND ufe.year_id = ?"
+		args = append(args, *yearFilter)
+	}
+
+	query += `
+        WHERE fs.delete_at IS NULL
             AND fs.status = 'active'
             AND fs.category_id = ?`
 
-	var args []interface{}
 	args = append(args, categoryID)
 
-	// Role-based filtering
 	if roleID != 3 { // Not admin
 		roleIDStr := fmt.Sprintf("%d", roleID)
 		query += " AND (fs.target_roles IS NULL OR fs.target_roles = '' OR JSON_CONTAINS(fs.target_roles, ?))"
 		args = append(args, fmt.Sprintf(`"%s"`, roleIDStr))
 	}
 
-	query += ` GROUP BY fs.subcategory_id, fs.subcategory_name, 
-               fs.fund_condition, fs.target_roles, fs.form_type, 
-               fs.form_url, fs.status
+	query += ` GROUP BY fs.subcategory_id, fs.subcategory_name,
+               fs.fund_condition, fs.target_roles, fs.form_type,
+               fs.form_url, fs.status,
+               ufe.user_fund_eligibility_id, ufe.remaining_quota,
+               ufe.max_allowed_amount, ufe.remaining_applications,
+               ufe.is_eligible, ufe.restriction_reason,
+               ufe.calculated_at, ufe.update_at
                ORDER BY fs.subcategory_id`
 
 	rows, err := config.DB.Raw(query, args...).Rows()
@@ -154,18 +201,26 @@ func getGroupedSubcategories(categoryID int, roleID int) []map[string]interface{
 
 	for rows.Next() {
 		var (
-			subID           int
-			subName         string
-			fundCondition   *string
-			targetRoles     *string
-			formType        *string
-			formURL         *string
-			status          string
-			allocatedAmount *float64 // เปลี่ยนเป็น pointer เพราะอาจเป็น NULL
-			remainingBudget *float64 // เปลี่ยนเป็น pointer เพราะอาจเป็น NULL
-			budgetCount     int
-			levels          *string
-			descriptions    *string
+			subID            int
+			subName          string
+			fundCondition    *string
+			targetRoles      *string
+			formType         *string
+			formURL          *string
+			status           string
+			allocatedAmount  *float64 // เปลี่ยนเป็น pointer เพราะอาจเป็น NULL
+			remainingBudget  *float64 // เปลี่ยนเป็น pointer เพราะอาจเป็น NULL
+			budgetCount      int
+			levels           *string
+			descriptions     *string
+			eligibilityID    *int
+			userQuota        *float64
+			userMaxAmount    *float64
+			userApplications *int
+			userEligible     *string
+			userRestriction  *string
+			userCalculated   *time.Time
+			userUpdated      *time.Time
 		)
 
 		err := rows.Scan(
@@ -181,6 +236,14 @@ func getGroupedSubcategories(categoryID int, roleID int) []map[string]interface{
 			&budgetCount,
 			&levels,
 			&descriptions,
+			&eligibilityID,
+			&userQuota,
+			&userMaxAmount,
+			&userApplications,
+			&userEligible,
+			&userRestriction,
+			&userCalculated,
+			&userUpdated,
 		)
 		if err != nil {
 			continue
@@ -202,6 +265,34 @@ func getGroupedSubcategories(categoryID int, roleID int) []map[string]interface{
 			remainingVal = *remainingBudget
 		}
 
+		eligibilityExists := eligibilityID != nil
+		eligibleFlag := true
+		if eligibilityExists && userEligible != nil {
+			normalized := strings.TrimSpace(strings.ToLower(*userEligible))
+			if normalized == "no" || normalized == "false" || normalized == "0" {
+				eligibleFlag = false
+			}
+		}
+
+		hasQuota := true
+		if eligibilityExists && userQuota != nil {
+			hasQuota = *userQuota > 0
+		}
+
+		hasApplications := true
+		if eligibilityExists && userApplications != nil {
+			hasApplications = *userApplications > 0
+		}
+
+		userCanApply := true
+		if eligibilityExists {
+			userCanApply = eligibleFlag && hasQuota && hasApplications
+		}
+
+		if filterIneligible && roleID != 3 && eligibilityExists && !userCanApply {
+			continue
+		}
+
 		subcategory := map[string]interface{}{
 			"subcategory_id":      subID,
 			"subcategory_name":    subName,
@@ -221,6 +312,55 @@ func getGroupedSubcategories(categoryID int, roleID int) []map[string]interface{
 			subcategory["budget_levels"] = levels
 			subcategory["budget_descriptions"] = descriptions
 		}
+
+		if eligibilityExists {
+			var eligibilityIDVal interface{}
+			if eligibilityID != nil {
+				eligibilityIDVal = *eligibilityID
+			}
+
+			var remainingQuotaVal interface{}
+			if userQuota != nil {
+				remainingQuotaVal = *userQuota
+			}
+
+			var maxAllowedVal interface{}
+			if userMaxAmount != nil {
+				maxAllowedVal = *userMaxAmount
+			}
+
+			var remainingAppsVal interface{}
+			if userApplications != nil {
+				remainingAppsVal = *userApplications
+			}
+
+			var eligibleValue interface{}
+			if userEligible != nil {
+				eligibleValue = *userEligible
+			}
+
+			var restrictionVal interface{}
+			if userRestriction != nil {
+				restrictionVal = *userRestriction
+			}
+
+			subcategory["user_eligibility"] = map[string]interface{}{
+				"user_fund_eligibility_id": eligibilityIDVal,
+				"remaining_quota":          remainingQuotaVal,
+				"max_allowed_amount":       maxAllowedVal,
+				"remaining_applications":   remainingAppsVal,
+				"is_eligible":              eligibleValue,
+				"restriction_reason":       restrictionVal,
+				"calculated_at":            userCalculated,
+				"updated_at":               userUpdated,
+				"has_quota":                hasQuota,
+				"has_applications":         hasApplications,
+				"is_eligible_flag":         eligibleFlag,
+				"can_apply":                userCanApply,
+			}
+		}
+
+		subcategory["user_can_apply"] = userCanApply
 
 		subcategories = append(subcategories, subcategory)
 	}

--- a/fund-management-api/controllers/submission.go
+++ b/fund-management-api/controllers/submission.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"fund-management-api/config"
 	"fund-management-api/models"
@@ -238,12 +239,51 @@ func CreateSubmission(c *gin.Context) {
 		return
 	}
 
+	userIDInt, ok := userID.(int)
+	if !ok {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Invalid user context"})
+		return
+	}
+
+	var resolvedCategoryID *int
+	if req.CategoryID != nil {
+		resolvedCategoryID = req.CategoryID
+	}
+	if resolvedCategoryID == nil && req.SubcategoryID != nil {
+		catID, err := resolveCategoryIDFromSubcategory(nil, *req.SubcategoryID)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Unable to determine category for subcategory"})
+			return
+		}
+		resolvedCategoryID = &catID
+	}
+
+	if resolvedCategoryID == nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Category or subcategory is required to evaluate eligibility"})
+		return
+	}
+
+	eligibility, err := findUserFundEligibility(nil, userIDInt, req.YearID, resolvedCategoryID, req.SubcategoryID)
+	if err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			c.JSON(http.StatusForbidden, gin.H{"error": "No eligibility record found for this fund"})
+		} else {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to verify eligibility"})
+		}
+		return
+	}
+
+	if err := ensureEligibilityAllowsStart(eligibility, nil); err != nil {
+		c.JSON(http.StatusForbidden, gin.H{"error": err.Error(), "eligibility": eligibility})
+		return
+	}
+
 	// Create submission
 	now := time.Now()
 	submission := models.Submission{
 		SubmissionType:   req.SubmissionType,
 		SubmissionNumber: generateSubmissionNumber(req.SubmissionType),
-		UserID:           userID.(int),
+		UserID:           userIDInt,
 		YearID:           req.YearID,
 		StatusID:         1,
 		CreatedAt:        now,

--- a/fund-management-api/models/user_fund_eligibility.go
+++ b/fund-management-api/models/user_fund_eligibility.go
@@ -1,0 +1,78 @@
+package models
+
+import (
+	"strings"
+	"time"
+)
+
+// UserFundEligibility represents the per-user quota tracking for each fund
+type UserFundEligibility struct {
+	UserFundEligibilityID int        `gorm:"primaryKey;column:user_fund_eligibility_id" json:"user_fund_eligibility_id"`
+	UserID                int        `gorm:"column:user_id" json:"user_id"`
+	YearID                int        `gorm:"column:year_id" json:"year_id"`
+	CategoryID            *int       `gorm:"column:category_id" json:"category_id"`
+	SubcategoryID         *int       `gorm:"column:subcategory_id" json:"subcategory_id"`
+	RemainingQuota        *float64   `gorm:"column:remaining_quota" json:"remaining_quota"`
+	MaxAllowedAmount      *float64   `gorm:"column:max_allowed_amount" json:"max_allowed_amount"`
+	RemainingApplications *int       `gorm:"column:remaining_applications" json:"remaining_applications"`
+	IsEligible            *string    `gorm:"column:is_eligible" json:"is_eligible"`
+	RestrictionReason     *string    `gorm:"column:restriction_reason" json:"restriction_reason"`
+	CalculatedAt          *time.Time `gorm:"column:calculated_at" json:"calculated_at"`
+	CreateAt              *time.Time `gorm:"column:create_at" json:"create_at"`
+	UpdateAt              *time.Time `gorm:"column:update_at" json:"update_at"`
+	DeleteAt              *time.Time `gorm:"column:delete_at" json:"delete_at"`
+}
+
+// TableName implements gorm's tablename interface
+func (UserFundEligibility) TableName() string {
+	return "user_fund_eligibilities"
+}
+
+// EligibleFlag returns true when the record marks the user as eligible for the fund
+func (ufe *UserFundEligibility) EligibleFlag() bool {
+	if ufe == nil {
+		return false
+	}
+	if ufe.IsEligible == nil {
+		return true
+	}
+
+	normalized := strings.TrimSpace(strings.ToLower(*ufe.IsEligible))
+	return normalized != "no" && normalized != "false" && normalized != "0"
+}
+
+// HasAnyQuota reports whether the user still has quota available (nil = unlimited)
+func (ufe *UserFundEligibility) HasAnyQuota() bool {
+	if ufe == nil {
+		return false
+	}
+	if ufe.RemainingQuota == nil {
+		return true
+	}
+	return *ufe.RemainingQuota > 0
+}
+
+// HasQuotaFor verifies the user has at least the requested amount of quota left
+func (ufe *UserFundEligibility) HasQuotaFor(amount float64) bool {
+	if ufe == nil {
+		return false
+	}
+	if amount <= 0 {
+		return ufe.HasAnyQuota()
+	}
+	if ufe.RemainingQuota == nil {
+		return true
+	}
+	return *ufe.RemainingQuota >= amount
+}
+
+// HasRemainingApplications reports whether the user can still submit another application
+func (ufe *UserFundEligibility) HasRemainingApplications() bool {
+	if ufe == nil {
+		return false
+	}
+	if ufe.RemainingApplications == nil {
+		return true
+	}
+	return *ufe.RemainingApplications > 0
+}


### PR DESCRIPTION
## Summary
- add a UserFundEligibility model plus shared helpers to locate and update per-user quotas
- surface eligibility data through fund structure and teacher subcategory endpoints and enforce limits when creating or approving submissions and applications
- show user-specific quota availability in the teacher and staff research fund tables

## Testing
- go test ./... *(hangs – aborted)*

------
https://chatgpt.com/codex/tasks/task_e_68cfc44172d4832a9ce685d04e6ab985