### PR TITLE
Add author metadata fields to publication reward flow

### DIFF
--- a/frontend_project_fund/app/lib/publication_api.js
+++ b/frontend_project_fund/app/lib/publication_api.js
@@ -205,7 +205,9 @@ export const publicationDetailsAPI = {
         is_corresponding_author: details.is_corresponding_author,
         author_status: details.author_status,
         author_type: details.author_status, // เพิ่ม author_type (ใช้ค่าเดียวกับ author_status)
-        
+        author_name_list: details.author_name_list,
+        signature: details.signature,
+
         // ข้อมูลธนาคาร
         bank_account: details.bank_account,
         bank_name: details.bank_name,

--- a/frontend_project_fund/app/member/components/applications/PublicationRewardForm.helpers.mjs
+++ b/frontend_project_fund/app/member/components/applications/PublicationRewardForm.helpers.mjs
@@ -1,0 +1,26 @@
+export const shouldDisableSubmitButton = ({
+  loading,
+  saving,
+  subcategoryId,
+  subcategoryBudgetId,
+  declarations,
+}) => {
+  return (
+    loading ||
+    saving ||
+    !subcategoryId ||
+    !subcategoryBudgetId ||
+    !declarations?.confirmNoPreviousFunding ||
+    !declarations?.agreeToRegulations
+  );
+};
+
+export const getAuthorSubmissionFields = (formData = {}) => {
+  const authorNameList = (formData.author_name_list || '').trim();
+  const signature = (formData.signature || '').trim();
+
+  return {
+    author_name_list: authorNameList,
+    signature,
+  };
+};

--- a/frontend_project_fund/app/member/components/applications/__tests__/PublicationRewardForm.helpers.test.mjs
+++ b/frontend_project_fund/app/member/components/applications/__tests__/PublicationRewardForm.helpers.test.mjs
@@ -1,0 +1,53 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  shouldDisableSubmitButton,
+  getAuthorSubmissionFields,
+} from '../PublicationRewardForm.helpers.mjs';
+
+test('shouldDisableSubmitButton enforces declaration requirements before enabling submit', () => {
+  const baseState = {
+    loading: false,
+    saving: false,
+    subcategoryId: 10,
+    subcategoryBudgetId: 20,
+    declarations: {
+      confirmNoPreviousFunding: false,
+      agreeToRegulations: false,
+    },
+  };
+
+  assert.equal(shouldDisableSubmitButton(baseState), true);
+
+  const oneChecked = {
+    ...baseState,
+    declarations: {
+      confirmNoPreviousFunding: true,
+      agreeToRegulations: false,
+    },
+  };
+  assert.equal(shouldDisableSubmitButton(oneChecked), true);
+
+  const bothChecked = {
+    ...baseState,
+    declarations: {
+      confirmNoPreviousFunding: true,
+      agreeToRegulations: true,
+    },
+  };
+  assert.equal(shouldDisableSubmitButton(bothChecked), false);
+});
+
+test('getAuthorSubmissionFields maps trimmed author fields for submission payload', () => {
+  const populated = getAuthorSubmissionFields({
+    author_name_list: '  Author One, Author Two  ',
+    signature: '  Dr. Example  ',
+  });
+
+  assert.equal(populated.author_name_list, 'Author One, Author Two');
+  assert.equal(populated.signature, 'Dr. Example');
+
+  const empty = getAuthorSubmissionFields();
+  assert.equal(empty.author_name_list, '');
+  assert.equal(empty.signature, '');
+});

--- a/frontend_project_fund/package.json
+++ b/frontend_project_fund/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "NEXT_DISABLE_FONT_DOWNLOAD=1 next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "node --test"
   },
   "dependencies": {
     "@ckeditor/ckeditor5-list": "^45.0.0",

--- a/fund-management-api/controllers/submission.go
+++ b/fund-management-api/controllers/submission.go
@@ -1077,8 +1077,10 @@ func AddPublicationDetails(c *gin.Context) {
 		TotalApproveAmount          float64 `json:"total_approve_amount"`
 
 		// === ข้อมูลผู้แต่ง ===
-		AuthorCount int    `json:"author_count"`
-		AuthorType  string `json:"author_status"` // FE เดิมส่งเป็น author_status
+		AuthorCount    int    `json:"author_count"`
+		AuthorType     string `json:"author_status"` // FE เดิมส่งเป็น author_status
+		AuthorNameList string `json:"author_name_list"`
+		Signature      string `json:"signature"`
 
 		// === อื่นๆ ===
 		AnnounceReferenceNumber string `json:"announce_reference_number"`
@@ -1139,6 +1141,18 @@ func AddPublicationDetails(c *gin.Context) {
 
 	now := time.Now()
 
+	trimmedAuthorNameList := strings.TrimSpace(req.AuthorNameList)
+	var authorNameListPtr *string
+	if trimmedAuthorNameList != "" {
+		authorNameListPtr = &trimmedAuthorNameList
+	}
+
+	trimmedSignature := strings.TrimSpace(req.Signature)
+	var signaturePtr *string
+	if trimmedSignature != "" {
+		signaturePtr = &trimmedSignature
+	}
+
 	publicationDetails := models.PublicationRewardDetail{
 		SubmissionID:    submission.SubmissionID,
 		PaperTitle:      req.PaperTitle,
@@ -1163,8 +1177,10 @@ func AddPublicationDetails(c *gin.Context) {
 		TotalAmount:                 req.TotalAmount,
 		TotalApproveAmount:          req.TotalApproveAmount,
 
-		AuthorCount: req.AuthorCount,
-		AuthorType:  req.AuthorType,
+		AuthorCount:    req.AuthorCount,
+		AuthorType:     req.AuthorType,
+		AuthorNameList: authorNameListPtr,
+		Signature:      signaturePtr,
 
 		AnnounceReferenceNumber: req.AnnounceReferenceNumber,
 

--- a/fund-management-api/models/submission.go
+++ b/fund-management-api/models/submission.go
@@ -91,8 +91,10 @@ type PublicationRewardDetail struct {
 	TotalApproveAmount          float64 `gorm:"column:total_approve_amount" json:"total_approve_amount"`       // จำนวนเงินจริงที่วิทยาลัยจ่ายให้ (หลังจากได้รับการอนุมัติ)
 
 	// === ข้อมูลผู้แต่ง ===
-	AuthorCount int    `gorm:"column:author_count" json:"author_count"`
-	AuthorType  string `gorm:"column:author_type;type:enum('first_author','corresponding_author','coauthor')" json:"author_type"` // เปลี่ยนจาก author_status
+	AuthorCount    int     `gorm:"column:author_count" json:"author_count"`
+	AuthorType     string  `gorm:"column:author_type;type:enum('first_author','corresponding_author','coauthor')" json:"author_type"` // เปลี่ยนจาก author_status
+	AuthorNameList *string `gorm:"column:author_name_list" json:"author_name_list,omitempty"`
+	Signature      *string `gorm:"column:signature" json:"signature,omitempty"`
 
 	// === อื่นๆ ===
 	AnnounceReferenceNumber string `gorm:"column:announce_reference_number" json:"announce_reference_number,omitempty"`

--- a/fund_cpkku_v39_add_author_signature.sql
+++ b/fund_cpkku_v39_add_author_signature.sql
@@ -1,0 +1,3 @@
+ALTER TABLE publication_reward_details
+  ADD COLUMN IF NOT EXISTS author_name_list TEXT NULL,
+  ADD COLUMN IF NOT EXISTS signature VARCHAR(255) NULL;


### PR DESCRIPTION
## Summary
- add an author name list textarea and signature input to the member publication reward form and include them in the submission payload
- require two declaration checkboxes before enabling submission and cover the logic with node-based unit tests
- extend the backend models/controllers and add a migration so author_name_list and signature are persisted

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d14a6eeaa0832a9a127c54e0adebd6