### PR TITLE
Add Dept Head review flow and gate admin approvals

### DIFF
--- a/frontend_project_fund/app/admin/components/submissions/GeneralSubmissionDetails.js
+++ b/frontend_project_fund/app/admin/components/submissions/GeneralSubmissionDetails.js
@@ -14,6 +14,7 @@ import StatusBadge from '../common/StatusBadge';
 import { formatCurrency } from '@/app/utils/format';
 import { adminSubmissionAPI } from '@/app/lib/admin_submission_api';
 import apiClient from '@/app/lib/api';
+import { requireStatusIds } from '@/app/lib/statusLookup';
 import { toast } from 'react-hot-toast';
 import Swal from 'sweetalert2';
 import 'sweetalert2/dist/sweetalert2.min.css';
@@ -76,16 +77,22 @@ const getUserFullName = (u) => {
   return name || (u.email || '-');
 };
 
+const STATUS_LABELS = [
+  'อยู่ระหว่างการพิจารณา',
+  'ต้องการข้อมูลเพิ่มเติม',
+  'อยู่ระหว่างการพิจารณาจากหัวหน้าสาขา',
+  'เห็นควรพิจารณาจากหัวหน้าสาขา',
+];
+
 /* =========================
  * Approval Panel
  *  - โหมด Pending (status_id=1): ฟอร์มอนุมัติ/ไม่อนุมัติ
  *  - โหมดอื่น: แสดงผลแบบ read-only เพื่อเทียบกับฝั่งซ้าย
  * ========================= */
-function FundApprovalPanel({ submission, fundDetail, onApprove, onReject }) {
+function FundApprovalPanel({ submission, fundDetail, onApprove, onReject, statusGuard }) {
   const statusId = Number(submission?.status_id);
   const requested = Number(fundDetail?.requested_amount || 0);
 
-  // ✅ เรียก Hooks เสมอเพื่อไม่ให้ผิดลำดับเมื่อสถานะเปลี่ยน
   const [approved, setApproved] = React.useState(
     Number.isFinite(Number(fundDetail?.approved_amount))
       ? Number(fundDetail?.approved_amount)
@@ -94,6 +101,18 @@ function FundApprovalPanel({ submission, fundDetail, onApprove, onReject }) {
   const [announceRef, setAnnounceRef] = React.useState(fundDetail?.announce_reference_number || '');
   const [comment, setComment] = React.useState(fundDetail?.comment || '');
   const [errors, setErrors] = React.useState({});
+
+  const pendingId = statusGuard?.pending ?? null;
+  const revisionId = statusGuard?.revision ?? null;
+  const deptPendingId = statusGuard?.deptPending ?? null;
+  const deptRecommendedId = statusGuard?.deptRecommended ?? null;
+
+  const interactiveStatuses = statusGuard
+    ? [pendingId, revisionId, deptRecommendedId].filter((id) => id != null)
+    : [];
+  const canInteract = interactiveStatuses.includes(statusId);
+  const awaitingDept = Boolean(statusGuard) && deptPendingId != null && statusId === deptPendingId;
+  const isDeptRecommended = Boolean(statusGuard) && deptRecommendedId != null && statusId === deptRecommendedId;
 
   const validate = () => {
     const e = {};
@@ -191,8 +210,25 @@ function FundApprovalPanel({ submission, fundDetail, onApprove, onReject }) {
     }
   };
 
-  // ====== READ-ONLY MODE (status_id !== 1) ======
-  if (statusId !== 1) {
+  if (!statusGuard) {
+    return (
+      <Card title="ผลการพิจารณา (Approval Result)" icon={FileText} collapsible={false}>
+        <div className="text-sm text-gray-500">กำลังโหลดข้อมูลสถานะจากระบบ...</div>
+      </Card>
+    );
+  }
+
+  if (awaitingDept) {
+    return (
+      <Card title="ผลการพิจารณา (Approval Result)" icon={FileText} collapsible={false}>
+        <div className="rounded-md border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-700">
+          รอการพิจารณาจากหัวหน้าสาขา
+        </div>
+      </Card>
+    );
+  }
+
+  if (!canInteract) {
     const approvedAmount =
       statusId === 2
         ? Number(
@@ -246,7 +282,6 @@ function FundApprovalPanel({ submission, fundDetail, onApprove, onReject }) {
     );
   }
 
-  // ====== PENDING MODE (status_id === 1) ======
   const headerTitle = (
     <div className="flex items-center justify-between w-full">
       <span>ผลการพิจารณา (Approval Result)</span>
@@ -259,7 +294,12 @@ function FundApprovalPanel({ submission, fundDetail, onApprove, onReject }) {
   return (
     <Card title={headerTitle} icon={FileText} collapsible={false}>
       <div className="space-y-5">
-        {/* Requested */}
+        {isDeptRecommended && (
+          <div className="rounded-md border border-green-200 bg-green-50 px-4 py-3 text-sm text-green-700">
+            หัวหน้าสาขาเห็นควรให้พิจารณาแล้ว
+          </div>
+        )}
+
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4 items-center">
           <label className="block text-sm font-medium text-gray-700 leading-tight">
             จำนวนเงินที่ขอ
@@ -270,7 +310,6 @@ function FundApprovalPanel({ submission, fundDetail, onApprove, onReject }) {
           </div>
         </div>
 
-        {/* Approved input - Fixed grid layout */}
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4 items-start">
           <label className="block text-sm font-medium text-gray-700 leading-tight">
             จำนวนเงินที่จะอนุมัติ
@@ -300,7 +339,6 @@ function FundApprovalPanel({ submission, fundDetail, onApprove, onReject }) {
           </div>
         </div>
 
-        {/* Announcement ref - Fixed grid layout */}
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4 items-center">
           <label className="block text-sm font-medium text-gray-700 leading-tight">
             หมายเลขอ้างอิงประกาศผลการพิจารณา (ถ้ามี)
@@ -317,7 +355,6 @@ function FundApprovalPanel({ submission, fundDetail, onApprove, onReject }) {
           </div>
         </div>
 
-        {/* Comment - Fixed grid layout */}
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4 items-start">
           <label className="block text-sm font-medium text-gray-700 leading-tight pt-2">
             หมายเหตุ / คำอธิบายเพิ่มเติม
@@ -333,7 +370,6 @@ function FundApprovalPanel({ submission, fundDetail, onApprove, onReject }) {
           </div>
         </div>
 
-        {/* Actions */}
         <div className="flex items-center gap-3 pt-4 border-t border-gray-200">
           <button className="btn btn-success" onClick={handleApprove}>อนุมัติ</button>
           <button className="btn btn-danger" onClick={handleReject}>ไม่อนุมัติ</button>
@@ -417,10 +453,32 @@ export default function GeneralSubmissionDetails({ submissionId, onBack }) {
   const [attachments, setAttachments] = useState([]);
   const [attachmentsLoading, setAttachmentsLoading] = useState(false);
 
+  const [statusRecords, setStatusRecords] = useState(null);
+
   // รวมไฟล์ PDF
   const [merging, setMerging] = useState(false);
   const mergedUrlRef = useRef(null);
   const [creatingMerged, setCreatingMerged] = useState(false);
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        const records = await requireStatusIds(STATUS_LABELS);
+        if (mounted) {
+          setStatusRecords(records);
+        }
+      } catch (error) {
+        if (mounted) {
+          console.error('load status lookup failed', error);
+          toast.error(error?.message || 'ไม่สามารถโหลดข้อมูลสถานะได้');
+        }
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, []);
 
   const cleanupMergedUrl = () => {
     if (mergedUrlRef.current) {
@@ -429,6 +487,17 @@ export default function GeneralSubmissionDetails({ submissionId, onBack }) {
     }
   };
   useEffect(() => () => cleanupMergedUrl(), []);
+
+  const statusGuard = useMemo(() => {
+    if (!statusRecords) return null;
+    const getId = (label) => statusRecords[label]?.id ?? null;
+    return {
+      pending: getId('อยู่ระหว่างการพิจารณา'),
+      revision: getId('ต้องการข้อมูลเพิ่มเติม'),
+      deptPending: getId('อยู่ระหว่างการพิจารณาจากหัวหน้าสาขา'),
+      deptRecommended: getId('เห็นควรพิจารณาจากหัวหน้าสาขา'),
+    };
+  }, [statusRecords]);
 
   // โหลดรายละเอียดคำร้อง
   useEffect(() => {
@@ -593,8 +662,28 @@ export default function GeneralSubmissionDetails({ submissionId, onBack }) {
   const submittedAt =
     submission?.submitted_at || submission?.created_at || submission?.create_at;
 
+  const ensureActionAllowed = () => {
+    if (!statusGuard) {
+      throw new Error('ไม่สามารถตรวจสอบสถานะจากระบบได้');
+    }
+    const currentStatusId = Number(submission?.status_id);
+    const allowed = [
+      statusGuard.pending,
+      statusGuard.revision,
+      statusGuard.deptRecommended,
+    ].filter((id) => id != null);
+
+    if (!allowed.includes(currentStatusId)) {
+      if (statusGuard.deptPending && currentStatusId === statusGuard.deptPending) {
+        throw new Error('คำร้องยังรอการพิจารณาจากหัวหน้าสาขา');
+      }
+      throw new Error('ไม่สามารถดำเนินการในสถานะปัจจุบันได้');
+    }
+  };
+
   // === API wiring สำหรับอนุมัติ/ไม่อนุมัติแบบ "ทั่วไป" ===
   const approve = async (payload) => {
+    ensureActionAllowed();
     await adminSubmissionAPI.approveSubmission(submission.submission_id, { ...payload });
     const res = await adminSubmissionAPI.getSubmissionDetails(submission.submission_id);
     let data = res?.submission || res;
@@ -607,6 +696,7 @@ export default function GeneralSubmissionDetails({ submissionId, onBack }) {
   };
 
   const reject = async (reason) => {
+    ensureActionAllowed();
     await adminSubmissionAPI.rejectSubmission(submission.submission_id, { rejection_reason: reason });
     const res = await adminSubmissionAPI.getSubmissionDetails(submission.submission_id);
     let data = res?.submission || res;
@@ -806,6 +896,7 @@ export default function GeneralSubmissionDetails({ submissionId, onBack }) {
           fundDetail={detail}
           onApprove={approve}
           onReject={reject}
+          statusGuard={statusGuard}
         />
       </div>
 

--- a/frontend_project_fund/app/admin/components/submissions/PublicationSubmissionDetails.js
+++ b/frontend_project_fund/app/admin/components/submissions/PublicationSubmissionDetails.js
@@ -32,6 +32,7 @@ import StatusBadge from '@/app/admin/components/common/StatusBadge';
 import apiClient from "@/app/lib/api";
 import { adminAnnouncementAPI } from "@/app/lib/admin_announcement_api";
 import { adminSubmissionAPI } from '@/app/lib/admin_submission_api';
+import { requireStatusIds } from '@/app/lib/statusLookup';
 import { rewardConfigAPI } from '@/app/lib/publication_api';
 import adminAPI from '@/app/lib/admin_api';
 import { notificationsAPI } from '@/app/lib/notifications_api';
@@ -40,6 +41,13 @@ import Swal from 'sweetalert2';
 import 'sweetalert2/dist/sweetalert2.min.css';
 
 import { PDFDocument } from 'pdf-lib';
+
+const STATUS_LABELS = [
+  'อยู่ระหว่างการพิจารณา',
+  'ต้องการข้อมูลเพิ่มเติม',
+  'อยู่ระหว่างการพิจารณาจากหัวหน้าสาขา',
+  'เห็นควรพิจารณาจากหัวหน้าสาขา',
+];
 
 /* =========================
  * Helpers
@@ -315,9 +323,36 @@ function ReadonlyMoney({ value, aria }) {
 /* =========================
  * Approval Panel (admin-only)
  * ========================= */
-function ApprovalPanel({ submission, pubDetail, onApprove, onReject }) {
-  const approvable = submission?.status_id === 1; // อยู่ระหว่างการพิจารณา
-  if (!approvable) return null;
+function ApprovalPanel({ submission, pubDetail, onApprove, onReject, statusGuard }) {
+  const statusId = Number(submission?.status_id);
+  const pendingId = statusGuard?.pending ?? null;
+  const revisionId = statusGuard?.revision ?? null;
+  const deptPendingId = statusGuard?.deptPending ?? null;
+  const deptRecommendedId = statusGuard?.deptRecommended ?? null;
+
+  const canInteract = statusGuard
+    ? [pendingId, revisionId, deptRecommendedId].filter((id) => id != null).includes(statusId)
+    : false;
+  const awaitingDept = Boolean(statusGuard) && deptPendingId != null && statusId === deptPendingId;
+  const isDeptRecommended = Boolean(statusGuard) && deptRecommendedId != null && statusId === deptRecommendedId;
+
+  if (!statusGuard) {
+    return (
+      <Card title="ผลการพิจารณา (Approval Result)" icon={FileText} collapsible={false}>
+        <div className="text-sm text-gray-500">กำลังโหลดข้อมูลสถานะจากระบบ...</div>
+      </Card>
+    );
+  }
+
+  if (awaitingDept) {
+    return (
+      <Card title="ผลการพิจารณา (Approval Result)" icon={FileText} collapsible={false}>
+        <div className="rounded-md border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-700">
+          รอการพิจารณาจากหัวหน้าสาขา
+        </div>
+      </Card>
+    );
+  }
 
   // Defaults from "ข้อมูลการเงิน"
   const requestedReward = Number(pubDetail?.reward_amount || 0);
@@ -704,9 +739,96 @@ function ApprovalPanel({ submission, pubDetail, onApprove, onReject }) {
     }
   };
 
+  if (!canInteract) {
+    const approvedReward = Number(
+      pubDetail?.reward_approve_amount ??
+      pubDetail?.approved_reward_amount ??
+      pubDetail?.reward_amount ?? 0
+    );
+    const approvedRevision = Number(
+      pubDetail?.revision_fee_approve_amount ??
+      pubDetail?.approve_revision_fee ??
+      pubDetail?.revision_fee ??
+      pubDetail?.editing_fee ?? 0
+    );
+    const approvedPublication = Number(
+      pubDetail?.publication_fee_approve_amount ??
+      pubDetail?.approve_publication_fee ??
+      pubDetail?.publication_fee ??
+      pubDetail?.page_charge ?? 0
+    );
+    const approvedTotal = Number(
+      pubDetail?.total_approve_amount ??
+      pubDetail?.approved_amount ??
+      (Number.isFinite(approvedReward) ? approvedReward : 0) +
+        (Number.isFinite(approvedRevision) ? approvedRevision : 0) +
+        (Number.isFinite(approvedPublication) ? approvedPublication : 0)
+    );
+
+    return (
+      <Card title="ผลการพิจารณา (Approval Result)" icon={FileText} collapsible={false}>
+        <div className="space-y-4 text-sm">
+          <div className="flex items-start justify-between">
+            <span className="text-gray-600">สถานะ</span>
+            <span className="font-medium"><StatusBadge statusId={submission?.status_id} /></span>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            <div className="flex items-start justify-between">
+              <span className="text-gray-600">เงินรางวัลที่ขอ</span>
+              <span className="font-semibold text-blue-700">฿{formatCurrency(requestedReward)}</span>
+            </div>
+            <div className="flex items-start justify-between">
+              <span className="text-gray-600">เงินรางวัลที่อนุมัติ</span>
+              <span className="font-medium">฿{formatCurrency(approvedReward)}</span>
+            </div>
+
+            {!hideSharedFeeFields && (
+              <>
+                <div className="flex items-start justify-between">
+                  <span className="text-gray-600">ค่าปรับปรุงบทความที่ขอ</span>
+                  <span className="font-semibold text-blue-700">฿{formatCurrency(requestedRevision)}</span>
+                </div>
+                <div className="flex items-start justify-between">
+                  <span className="text-gray-600">ค่าปรับปรุงบทความที่อนุมัติ</span>
+                  <span className="font-medium">฿{formatCurrency(approvedRevision)}</span>
+                </div>
+                <div className="flex items-start justify-between">
+                  <span className="text-gray-600">ค่าธรรมเนียมการตีพิมพ์ที่ขอ</span>
+                  <span className="font-semibold text-blue-700">฿{formatCurrency(requestedPublication)}</span>
+                </div>
+                <div className="flex items-start justify-between">
+                  <span className="text-gray-600">ค่าธรรมเนียมการตีพิมพ์ที่อนุมัติ</span>
+                  <span className="font-medium">฿{formatCurrency(approvedPublication)}</span>
+                </div>
+              </>
+            )}
+
+            <div className="flex items-start justify-between md:col-span-2">
+              <span className="text-gray-600">รวมจำนวนเงินที่อนุมัติ</span>
+              <span className="font-semibold text-blue-700">฿{formatCurrency(approvedTotal)}</span>
+            </div>
+          </div>
+
+          {pubDetail?.announce_reference_number && (
+            <div className="flex items-start justify-between">
+              <span className="text-gray-600">หมายเลขอ้างอิงประกาศผลการพิจารณา</span>
+              <span className="font-medium break-all">{pubDetail.announce_reference_number}</span>
+            </div>
+          )}
+        </div>
+      </Card>
+    );
+  }
+
   return (
     <Card title="ผลการพิจารณา (Approval Result)" icon={DollarSign} collapsible={false}>
       <div className="space-y-4">
+        {isDeptRecommended && (
+          <div className="rounded-md border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">
+            หัวหน้าสาขาเห็นควรให้พิจารณาคำร้องนี้แล้ว สามารถดำเนินการได้
+          </div>
+        )}
         {/* Header: only Approved column */}
         <div className="grid grid-cols-2 pb-2 border-b text-sm text-gray-600">
           <div></div>
@@ -907,6 +1029,39 @@ export default function PublicationSubmissionDetails({ submissionId, onBack }) {
 
   const [attachments, setAttachments] = useState([]);
   const [attachmentsLoading, setAttachmentsLoading] = useState(false)
+
+  const [statusRecords, setStatusRecords] = useState(null);
+
+  useEffect(() => {
+    let mounted = true;
+    (async () => {
+      try {
+        const records = await requireStatusIds(STATUS_LABELS);
+        if (mounted) {
+          setStatusRecords(records);
+        }
+      } catch (error) {
+        if (mounted) {
+          console.error('load publication status lookup failed', error);
+          toast.error(error?.message || 'ไม่สามารถโหลดข้อมูลสถานะได้');
+        }
+      }
+    })();
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const statusGuard = useMemo(() => {
+    if (!statusRecords) return null;
+    const getId = (label) => statusRecords[label]?.id ?? null;
+    return {
+      pending: getId('อยู่ระหว่างการพิจารณา'),
+      revision: getId('ต้องการข้อมูลเพิ่มเติม'),
+      deptPending: getId('อยู่ระหว่างการพิจารณาจากหัวหน้าสาขา'),
+      deptRecommended: getId('เห็นควรพิจารณาจากหัวหน้าสาขา'),
+    };
+  }, [statusRecords]);
 
   // Load data
   useEffect(() => {
@@ -1148,6 +1303,26 @@ export default function PublicationSubmissionDetails({ submissionId, onBack }) {
 
   // shared cap ถือว่ามี ก็ต่อเมื่อดึงมาได้เป็นตัวเลข > 0 เท่านั้น (ถ้า null/0 = ไม่มี)
   const hasSharedCap = typeof feeCap === 'number' && feeCap > 0;
+
+  const ensureActionAllowed = () => {
+    if (!statusGuard) {
+      throw new Error('ไม่สามารถตรวจสอบสถานะจากระบบได้');
+    }
+
+    const currentStatusId = Number(submission?.status_id);
+    const allowed = [
+      statusGuard.pending,
+      statusGuard.revision,
+      statusGuard.deptRecommended,
+    ].filter((id) => id != null);
+
+    if (!allowed.includes(currentStatusId)) {
+      if (statusGuard.deptPending && currentStatusId === statusGuard.deptPending) {
+        throw new Error('คำร้องยังรอการพิจารณาจากหัวหน้าสาขา');
+      }
+      throw new Error('ไม่สามารถดำเนินการในสถานะปัจจุบันได้');
+    }
+  };
 
   // มีตัวเลขฝั่งอนุมัติแล้วหรือยัง
   const hasRevisionApproved    = pubDetail?.revision_fee_approve_amount != null;
@@ -1395,6 +1570,7 @@ export default function PublicationSubmissionDetails({ submissionId, onBack }) {
 
   // Admin actions → API wiring
   const approve = async (payload) => {
+    ensureActionAllowed();
     // ส่งตัวเลขอนุมัติ + หมายเลขอ้างอิงประกาศ ไปในคำสั่งอนุมัติครั้งเดียว
     await adminSubmissionAPI.approveSubmission(submission.submission_id, payload);
 
@@ -1410,6 +1586,7 @@ export default function PublicationSubmissionDetails({ submissionId, onBack }) {
   };
 
   const reject = async (reason) => {
+    ensureActionAllowed();
     await adminSubmissionAPI.rejectSubmission(submission.submission_id, { rejection_reason: reason });
     // reload
     const res = await adminSubmissionAPI.getSubmissionDetails(submission.submission_id);
@@ -1989,6 +2166,7 @@ export default function PublicationSubmissionDetails({ submissionId, onBack }) {
             pubDetail={pubDetail}
             onApprove={approve}
             onReject={reject}
+            statusGuard={statusGuard}
           />
         </div>
       )}

--- a/frontend_project_fund/app/lib/publication_api.js
+++ b/frontend_project_fund/app/lib/publication_api.js
@@ -22,6 +22,7 @@ export const submissionAPI = {
       if (data.category_id) payload.category_id = data.category_id;
       if (data.subcategory_id) payload.subcategory_id = data.subcategory_id;
       if (data.subcategory_budget_id) payload.subcategory_budget_id = data.subcategory_budget_id;
+      if (data.status_id) payload.status_id = data.status_id;
 
       const response = await apiClient.post('/submissions', payload);
       return response;

--- a/frontend_project_fund/app/lib/statusLookup.js
+++ b/frontend_project_fund/app/lib/statusLookup.js
@@ -1,0 +1,108 @@
+// app/lib/statusLookup.js - Helpers for resolving application status IDs dynamically
+import apiClient from './api';
+
+let statusesPromise = null;
+
+const normalizeRecord = (record) => {
+  if (!record || typeof record !== 'object') return null;
+  const id =
+    record.application_status_id ??
+    record.status_id ??
+    record.id ??
+    null;
+  if (id == null) return null;
+  const name = record.status_name || record.name || '';
+  return {
+    id: Number(id),
+    name,
+    raw: record,
+  };
+};
+
+export const resetStatusesCache = () => {
+  statusesPromise = null;
+};
+
+export const fetchApplicationStatuses = async (force = false) => {
+  if (!force && statusesPromise) {
+    return statusesPromise;
+  }
+
+  statusesPromise = apiClient
+    .get('/application-status')
+    .then((response) => {
+      const list =
+        response?.statuses ||
+        response?.data?.statuses ||
+        response?.data ||
+        [];
+      if (!Array.isArray(list) || list.length === 0) {
+        throw new Error('ไม่พบข้อมูลสถานะจากระบบ');
+      }
+      return list.map(normalizeRecord).filter(Boolean);
+    })
+    .catch((error) => {
+      statusesPromise = null;
+      throw error;
+    });
+
+  return statusesPromise;
+};
+
+const matchStatusByLabel = (statuses, label) => {
+  if (!Array.isArray(statuses)) return null;
+  const matches = statuses.filter(
+    (status) =>
+      typeof status?.name === 'string' &&
+      status.name.includes(label)
+  );
+
+  if (matches.length === 0) {
+    throw new Error(`ไม่พบสถานะที่มีคำว่า “${label}”`);
+  }
+  if (matches.length > 1) {
+    throw new Error(`พบสถานะหลายรายการที่มีคำว่า “${label}”`);
+  }
+
+  return matches[0];
+};
+
+export const findStatusRecordByLabel = async (label) => {
+  if (!label) {
+    throw new Error('ต้องระบุคำค้นหาสถานะ');
+  }
+  const statuses = await fetchApplicationStatuses();
+  return matchStatusByLabel(statuses, label);
+};
+
+export const findStatusIdByLabel = async (label) => {
+  const record = await findStatusRecordByLabel(label);
+  if (!record?.id) {
+    throw new Error(`ไม่สามารถระบุรหัสสถานะของ “${label}” ได้`);
+  }
+  return record.id;
+};
+
+export const requireStatusIds = async (labels) => {
+  if (!Array.isArray(labels) || labels.length === 0) {
+    throw new Error('ต้องระบุรายชื่อสถานะอย่างน้อยหนึ่งรายการ');
+  }
+
+  const statuses = await fetchApplicationStatuses();
+  const result = {};
+
+  labels.forEach((label) => {
+    const record = matchStatusByLabel(statuses, label);
+    result[label] = record;
+  });
+
+  return result;
+};
+
+export default {
+  fetchApplicationStatuses,
+  findStatusIdByLabel,
+  findStatusRecordByLabel,
+  requireStatusIds,
+  resetStatusesCache,
+};

--- a/frontend_project_fund/app/member/components/applications/GenericFundApplicationForm.js
+++ b/frontend_project_fund/app/member/components/applications/GenericFundApplicationForm.js
@@ -10,6 +10,7 @@ import { authAPI, systemAPI } from '../../../lib/api';
 // เพิ่ม apiClient สำหรับเรียก API โดยตรง
 import apiClient from '../../../lib/api';
 import { submissionAPI, documentAPI, fileAPI} from '../../../lib/member_api';
+import { requireStatusIds } from '../../../lib/statusLookup';
 
 // =================================================================
 // FILE UPLOAD COMPONENT
@@ -362,10 +363,19 @@ export default function GenericFundApplicationForm({ onNavigate, subcategoryData
         return;
       }
 
+      const statusRecords = await requireStatusIds([
+        'อยู่ระหว่างการพิจารณาจากหัวหน้าสาขา',
+      ]);
+      const deptPendingStatusId = statusRecords['อยู่ระหว่างการพิจารณาจากหัวหน้าสาขา']?.id;
+      if (!deptPendingStatusId) {
+        throw new Error('ไม่พบรหัสสถานะสำหรับการพิจารณาของหัวหน้าสาขา');
+      }
+
       // Step 1: Create submission record
       const submissionRes = await submissionAPI.createSubmission({
         submission_type: 'fund_application',
-        year_id: subcategoryData?.year_id
+        year_id: subcategoryData?.year_id,
+        status_id: deptPendingStatusId,
       });
       const submissionId = submissionRes?.submission?.submission_id;
 

--- a/frontend_project_fund/app/member/components/applications/PublicationRewardForm.js
+++ b/frontend_project_fund/app/member/components/applications/PublicationRewardForm.js
@@ -21,6 +21,7 @@ import Swal from 'sweetalert2';
 import { PDFDocument } from 'pdf-lib';
 import { notificationsAPI } from '../../../lib/notifications_api';
 import { systemConfigAPI } from '../../../lib/system_config_api';
+import { requireStatusIds } from '../../../lib/statusLookup';
 
 // =================================================================
 // CONFIGURATION & CONSTANTS
@@ -2259,6 +2260,14 @@ const showSubmissionConfirmation = async () => {
 
       console.log(`Total files to upload: ${allFiles.length}`);
 
+      const statusRecords = await requireStatusIds([
+        'อยู่ระหว่างการพิจารณาจากหัวหน้าสาขา',
+      ]);
+      const deptPendingStatusId = statusRecords['อยู่ระหว่างการพิจารณาจากหัวหน้าสาขา']?.id;
+      if (!deptPendingStatusId) {
+        throw new Error('ไม่พบรหัสสถานะสำหรับการพิจารณาของหัวหน้าสาขา');
+      }
+
       // Create submission if not exists
       if (!submissionId) {
         Swal.update({
@@ -2277,6 +2286,7 @@ const showSubmissionConfirmation = async () => {
           category_id: formData.category_id || categoryId,
           subcategory_id: formData.subcategory_id,        // Dynamic resolved
           subcategory_budget_id: formData.subcategory_budget_id,  // Dynamic resolved
+          status_id: deptPendingStatusId,
         });
         
         submissionId = submissionResponse.submission.submission_id;

--- a/fund-management-api/controllers/admin_submission.go
+++ b/fund-management-api/controllers/admin_submission.go
@@ -2,14 +2,22 @@
 package controllers
 
 import (
-	"fund-management-api/config"
-	"fund-management-api/models"
-	"net/http"
-	"strconv"
-	"strings"
-	"time"
+        "fund-management-api/config"
+        "fund-management-api/models"
+        "fund-management-api/utils"
+        "net/http"
+        "strconv"
+        "strings"
+        "time"
 
-	"github.com/gin-gonic/gin"
+        "github.com/gin-gonic/gin"
+)
+
+const (
+        statusLabelPendingGeneral     = "อยู่ระหว่างการพิจารณา"
+        statusLabelRevisionRequested  = "ต้องการข้อมูลเพิ่มเติม"
+        statusLabelDeptPending        = "อยู่ระหว่างการพิจารณาจากหัวหน้าสาขา"
+        statusLabelDeptRecommended    = "เห็นควรพิจารณาจากหัวหน้าสาขา"
 )
 
 // ==============================
@@ -277,12 +285,40 @@ func ApproveSubmission(c *gin.Context) {
 		return
 	}
 
-	// Validate status (1=pending, 4=revision requested)
-	if submission.StatusID != 1 && submission.StatusID != 4 {
-		tx.Rollback()
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Only pending or revision-requested submissions can be approved"})
-		return
-	}
+        statusMap, err := utils.ResolveStatusesByLabels([]string{
+                statusLabelPendingGeneral,
+                statusLabelRevisionRequested,
+                statusLabelDeptPending,
+                statusLabelDeptRecommended,
+        })
+        if err != nil {
+                tx.Rollback()
+                c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+                return
+        }
+
+        allowedStatuses := map[int]bool{}
+        if s, ok := statusMap[statusLabelPendingGeneral]; ok {
+                allowedStatuses[s.ApplicationStatusID] = true
+        }
+        if s, ok := statusMap[statusLabelRevisionRequested]; ok {
+                allowedStatuses[s.ApplicationStatusID] = true
+        }
+        if s, ok := statusMap[statusLabelDeptRecommended]; ok {
+                allowedStatuses[s.ApplicationStatusID] = true
+        }
+
+        deptPendingID := statusMap[statusLabelDeptPending].ApplicationStatusID
+
+        if !allowedStatuses[submission.StatusID] {
+                tx.Rollback()
+                if submission.StatusID == deptPendingID {
+                        c.JSON(http.StatusBadRequest, gin.H{"error": "Submission is awaiting department head review"})
+                } else {
+                        c.JSON(http.StatusBadRequest, gin.H{"error": "Only pending, revision-requested, or department-recommended submissions can be approved"})
+                }
+                return
+        }
 
 	// Update submission status → approved
 	now := time.Now()
@@ -406,12 +442,40 @@ func RejectSubmission(c *gin.Context) {
 		return
 	}
 
-	// Only pending (1) or revision-requested (4) can be rejected
-	if submission.StatusID != 1 && submission.StatusID != 4 {
-		tx.Rollback()
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Only pending or revision-requested submissions can be rejected"})
-		return
-	}
+        statusMap, err := utils.ResolveStatusesByLabels([]string{
+                statusLabelPendingGeneral,
+                statusLabelRevisionRequested,
+                statusLabelDeptPending,
+                statusLabelDeptRecommended,
+        })
+        if err != nil {
+                tx.Rollback()
+                c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+                return
+        }
+
+        allowedStatuses := map[int]bool{}
+        if s, ok := statusMap[statusLabelPendingGeneral]; ok {
+                allowedStatuses[s.ApplicationStatusID] = true
+        }
+        if s, ok := statusMap[statusLabelRevisionRequested]; ok {
+                allowedStatuses[s.ApplicationStatusID] = true
+        }
+        if s, ok := statusMap[statusLabelDeptRecommended]; ok {
+                allowedStatuses[s.ApplicationStatusID] = true
+        }
+
+        deptPendingID := statusMap[statusLabelDeptPending].ApplicationStatusID
+
+        if !allowedStatuses[submission.StatusID] {
+                tx.Rollback()
+                if submission.StatusID == deptPendingID {
+                        c.JSON(http.StatusBadRequest, gin.H{"error": "Submission is awaiting department head review"})
+                } else {
+                        c.JSON(http.StatusBadRequest, gin.H{"error": "Only pending, revision-requested, or department-recommended submissions can be rejected"})
+                }
+                return
+        }
 
 	now := time.Now()
 	submission.StatusID = 3

--- a/fund-management-api/controllers/dept_head.go
+++ b/fund-management-api/controllers/dept_head.go
@@ -1,0 +1,272 @@
+package controllers
+
+import (
+        "net/http"
+        "strconv"
+        "strings"
+        "time"
+
+        "github.com/gin-gonic/gin"
+
+        "fund-management-api/config"
+        "fund-management-api/models"
+        "fund-management-api/utils"
+)
+
+const (
+        statusLabelDeptPending     = "อยู่ระหว่างการพิจารณาจากหัวหน้าสาขา"
+        statusLabelDeptRecommended = "เห็นควรพิจารณาจากหัวหน้าสาขา"
+        statusLabelDeptRejected    = "ไม่เห็นควรพิจารณา"
+)
+
+func getDeptHeadStatusMap() (map[string]models.ApplicationStatus, error) {
+        labels := []string{
+                statusLabelDeptPending,
+                statusLabelDeptRecommended,
+                statusLabelDeptRejected,
+        }
+        return utils.ResolveStatusesByLabels(labels)
+}
+
+// GetDeptHeadSubmissions lists submissions awaiting department head review.
+func GetDeptHeadSubmissions(c *gin.Context) {
+        statusMap, err := getDeptHeadStatusMap()
+        if err != nil {
+                c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+                return
+        }
+
+        pendingID := statusMap[statusLabelDeptPending].ApplicationStatusID
+
+        var submissions []models.Submission
+        query := config.DB.
+                Preload("User").
+                Preload("Status").
+                Preload("Category").
+                Preload("Subcategory").
+                Where("status_id = ? AND deleted_at IS NULL", pendingID).
+                Order("submitted_at IS NULL ASC").
+                Order("submitted_at ASC").
+                Order("created_at ASC")
+
+        if err := query.Find(&submissions).Error; err != nil {
+                c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch submissions"})
+                return
+        }
+
+        c.JSON(http.StatusOK, gin.H{
+                "success":     true,
+                "submissions": submissions,
+                "total":       len(submissions),
+        })
+}
+
+// DeptHeadRecommendSubmission records a positive recommendation and forwards to admin.
+func DeptHeadRecommendSubmission(c *gin.Context) {
+        submissionID, err := strconv.Atoi(c.Param("id"))
+        if err != nil {
+                c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid submission ID"})
+                return
+        }
+        userIDVal, _ := c.Get("userID")
+        reviewerID, _ := userIDVal.(int)
+
+        var req struct {
+                Comment string `json:"comment"`
+        }
+        if err := c.ShouldBindJSON(&req); err != nil && err.Error() != "EOF" {
+                c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid payload"})
+                return
+        }
+
+        statusMap, err := getDeptHeadStatusMap()
+        if err != nil {
+                c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+                return
+        }
+
+        pendingID := statusMap[statusLabelDeptPending].ApplicationStatusID
+        recommendedID := statusMap[statusLabelDeptRecommended].ApplicationStatusID
+
+        tx := config.DB.Begin()
+
+        var submission models.Submission
+        if err := tx.Where("submission_id = ? AND deleted_at IS NULL", submissionID).
+                First(&submission).Error; err != nil {
+                tx.Rollback()
+                c.JSON(http.StatusNotFound, gin.H{"error": "Submission not found"})
+                return
+        }
+
+        if submission.StatusID != pendingID {
+                tx.Rollback()
+                c.JSON(http.StatusBadRequest, gin.H{"error": "Submission is not awaiting department review"})
+                return
+        }
+
+        now := time.Now()
+        comment := strings.TrimSpace(req.Comment)
+
+        updates := map[string]interface{}{
+                "status_id":        recommendedID,
+                "head_approved_by": reviewerID,
+                "head_approved_at": now,
+                "updated_at":       now,
+        }
+        if comment != "" {
+                updates["comment"] = comment
+        }
+
+        if err := tx.Model(&models.Submission{}).
+                Where("submission_id = ?", submissionID).
+                Updates(updates).Error; err != nil {
+                tx.Rollback()
+                c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update submission"})
+                return
+        }
+
+        history := models.SubmissionStatusHistory{
+                SubmissionID: submission.SubmissionID,
+                NewStatusID:  recommendedID,
+                ChangedBy:    reviewerID,
+                CreatedAt:    now,
+        }
+        oldStatus := submission.StatusID
+        history.OldStatusID = &oldStatus
+        if comment != "" {
+                history.Notes = &comment
+        }
+
+        if err := tx.Create(&history).Error; err != nil {
+                tx.Rollback()
+                c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to record status history"})
+                return
+        }
+
+        if err := tx.Commit().Error; err != nil {
+                c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save recommendation"})
+                return
+        }
+
+        var updated models.Submission
+        if err := config.DB.Preload("User").
+                Preload("Status").
+                Preload("Category").
+                Preload("Subcategory").
+                Where("submission_id = ?", submissionID).
+                First(&updated).Error; err != nil {
+                c.JSON(http.StatusOK, gin.H{"success": true, "message": "Submission forwarded"})
+                return
+        }
+
+        c.JSON(http.StatusOK, gin.H{
+                "success":    true,
+                "message":    "Submission forwarded",
+                "submission": updated,
+        })
+}
+
+// DeptHeadRejectSubmission marks the submission as not recommended by the department head.
+func DeptHeadRejectSubmission(c *gin.Context) {
+        submissionID, err := strconv.Atoi(c.Param("id"))
+        if err != nil {
+                c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid submission ID"})
+                return
+        }
+        userIDVal, _ := c.Get("userID")
+        reviewerID, _ := userIDVal.(int)
+
+        var req struct {
+                Comment string `json:"comment"`
+        }
+        if err := c.ShouldBindJSON(&req); err != nil && err.Error() != "EOF" {
+                c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid payload"})
+                return
+        }
+
+        statusMap, err := getDeptHeadStatusMap()
+        if err != nil {
+                c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+                return
+        }
+
+        pendingID := statusMap[statusLabelDeptPending].ApplicationStatusID
+        rejectedID := statusMap[statusLabelDeptRejected].ApplicationStatusID
+
+        tx := config.DB.Begin()
+
+        var submission models.Submission
+        if err := tx.Where("submission_id = ? AND deleted_at IS NULL", submissionID).
+                First(&submission).Error; err != nil {
+                tx.Rollback()
+                c.JSON(http.StatusNotFound, gin.H{"error": "Submission not found"})
+                return
+        }
+
+        if submission.StatusID != pendingID {
+                tx.Rollback()
+                c.JSON(http.StatusBadRequest, gin.H{"error": "Submission is not awaiting department review"})
+                return
+        }
+
+        now := time.Now()
+        comment := strings.TrimSpace(req.Comment)
+
+        updates := map[string]interface{}{
+                "status_id":        rejectedID,
+                "head_approved_by": reviewerID,
+                "head_approved_at": now,
+                "updated_at":       now,
+        }
+        if comment != "" {
+                updates["comment"] = comment
+        }
+
+        if err := tx.Model(&models.Submission{}).
+                Where("submission_id = ?", submissionID).
+                Updates(updates).Error; err != nil {
+                tx.Rollback()
+                c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update submission"})
+                return
+        }
+
+        history := models.SubmissionStatusHistory{
+                SubmissionID: submission.SubmissionID,
+                NewStatusID:  rejectedID,
+                ChangedBy:    reviewerID,
+                CreatedAt:    now,
+        }
+        oldStatus := submission.StatusID
+        history.OldStatusID = &oldStatus
+        if comment != "" {
+                history.Notes = &comment
+        }
+
+        if err := tx.Create(&history).Error; err != nil {
+                tx.Rollback()
+                c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to record status history"})
+                return
+        }
+
+        if err := tx.Commit().Error; err != nil {
+                c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save decision"})
+                return
+        }
+
+        var updated models.Submission
+        if err := config.DB.Preload("User").
+                Preload("Status").
+                Preload("Category").
+                Preload("Subcategory").
+                Where("submission_id = ?", submissionID).
+                First(&updated).Error; err != nil {
+                c.JSON(http.StatusOK, gin.H{"success": true, "message": "Submission marked as not recommended"})
+                return
+        }
+
+        c.JSON(http.StatusOK, gin.H{
+                "success":    true,
+                "message":    "Submission marked as not recommended",
+                "submission": updated,
+        })
+}

--- a/fund-management-api/controllers/submission.go
+++ b/fund-management-api/controllers/submission.go
@@ -203,13 +203,14 @@ func GetSubmission(c *gin.Context) {
 func CreateSubmission(c *gin.Context) {
 	userID, _ := c.Get("userID")
 
-	type CreateSubmissionRequest struct {
-		SubmissionType      string `json:"submission_type" binding:"required"` // 'fund_application', 'publication_reward', ...
-		YearID              int    `json:"year_id" binding:"required"`
-		CategoryID          *int   `json:"category_id"`           // <-- ใหม่
-		SubcategoryID       *int   `json:"subcategory_id"`        // <-- ใหม่
-		SubcategoryBudgetID *int   `json:"subcategory_budget_id"` // <-- ใหม่
-	}
+        type CreateSubmissionRequest struct {
+                SubmissionType      string `json:"submission_type" binding:"required"` // 'fund_application', 'publication_reward', ...
+                YearID              int    `json:"year_id" binding:"required"`
+                CategoryID          *int   `json:"category_id"`           // <-- ใหม่
+                SubcategoryID       *int   `json:"subcategory_id"`        // <-- ใหม่
+                SubcategoryBudgetID *int   `json:"subcategory_budget_id"` // <-- ใหม่
+                StatusID            *int   `json:"status_id"`
+        }
 
 	var req CreateSubmissionRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -238,17 +239,34 @@ func CreateSubmission(c *gin.Context) {
 		return
 	}
 
-	// Create submission
-	now := time.Now()
-	submission := models.Submission{
-		SubmissionType:   req.SubmissionType,
-		SubmissionNumber: generateSubmissionNumber(req.SubmissionType),
-		UserID:           userID.(int),
-		YearID:           req.YearID,
-		StatusID:         1,
-		CreatedAt:        now,
-		UpdatedAt:        now,
-	}
+        var statusID int
+        if req.StatusID != nil {
+                var status models.ApplicationStatus
+                if err := config.DB.Where("application_status_id = ?", *req.StatusID).First(&status).Error; err != nil {
+                        c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid status_id"})
+                        return
+                }
+                statusID = status.ApplicationStatusID
+        } else {
+                resolvedID, err := utils.ResolveStatusIDByLabel("อยู่ระหว่างการพิจารณา")
+                if err != nil {
+                        c.JSON(http.StatusInternalServerError, gin.H{"error": fmt.Sprintf("Failed to resolve default status: %v", err)})
+                        return
+                }
+                statusID = resolvedID
+        }
+
+        // Create submission
+        now := time.Now()
+        submission := models.Submission{
+                SubmissionType:   req.SubmissionType,
+                SubmissionNumber: generateSubmissionNumber(req.SubmissionType),
+                UserID:           userID.(int),
+                YearID:           req.YearID,
+                StatusID:         statusID,
+                CreatedAt:        now,
+                UpdatedAt:        now,
+        }
 
 	// เซ็ตฟิลด์หมวดหมู่ถ้ามีส่งมา
 	if req.CategoryID != nil {

--- a/fund-management-api/models/submission.go
+++ b/fund-management-api/models/submission.go
@@ -18,14 +18,18 @@ type Submission struct {
 	SubcategoryID           *int       `gorm:"column:subcategory_id" json:"subcategory_id"`               // ✅ เพิ่มใหม่
 	SubcategoryName         *string    `gorm:"column:subcategory_name;->" json:"subcategory_name"`        // ✅ เพิ่มใหม่ (read-only, มาจาก join)
 	SubcategoryBudgetID     *int       `gorm:"column:subcategory_budget_id" json:"subcategory_budget_id"` // ✅ เพิ่มใหม่
-	StatusID                int        `gorm:"column:status_id" json:"status_id"`
-	ApprovedBy              *int       `gorm:"column:approved_by" json:"approved_by"`
-	ApprovedAt              *time.Time `gorm:"column:approved_at" json:"approved_at"`
-	SubmittedAt             *time.Time `gorm:"column:submitted_at" json:"submitted_at"`
-	CreatedAt               time.Time  `gorm:"column:created_at" json:"created_at"`
-	UpdatedAt               time.Time  `gorm:"column:updated_at" json:"updated_at"`
-	DeletedAt               *time.Time `gorm:"column:deleted_at" json:"deleted_at"`
-	AnnounceReferenceNumber string     `gorm:"-" json:"announce_reference_number,omitempty"`
+        StatusID                int        `gorm:"column:status_id" json:"status_id"`
+        ApprovedBy              *int       `gorm:"column:approved_by" json:"approved_by"`
+        ApprovedAt              *time.Time `gorm:"column:approved_at" json:"approved_at"`
+        SubmittedAt             *time.Time `gorm:"column:submitted_at" json:"submitted_at"`
+        ReviewedAt              *time.Time `gorm:"column:reviewed_at" json:"reviewed_at,omitempty"`
+        HeadApprovedAt          *time.Time `gorm:"column:head_approved_at" json:"head_approved_at,omitempty"`
+        HeadApprovedBy          *int       `gorm:"column:head_approved_by" json:"head_approved_by,omitempty"`
+        CreatedAt               time.Time  `gorm:"column:created_at" json:"created_at"`
+        UpdatedAt               time.Time  `gorm:"column:updated_at" json:"updated_at"`
+        DeletedAt               *time.Time `gorm:"column:deleted_at" json:"deleted_at"`
+        Comment                 *string    `gorm:"column:comment" json:"comment,omitempty"`
+        AnnounceReferenceNumber string     `gorm:"-" json:"announce_reference_number,omitempty"`
 
 	// Relations
 	User                    *User                    `gorm:"foreignKey:UserID" json:"user,omitempty"`
@@ -129,10 +133,10 @@ type PublicationRewardDetail struct {
 
 // SubmissionDocument represents the submission_documents table (junction table)
 type SubmissionDocument struct {
-	DocumentID       int        `gorm:"primaryKey;column:document_id" json:"document_id"`
-	SubmissionID     int        `gorm:"column:submission_id" json:"submission_id"`
-	FileID           int        `gorm:"column:file_id" json:"file_id"`
-	DocumentTypeID   int        `gorm:"column:document_type_id" json:"document_type_id"`
+        DocumentID       int        `gorm:"primaryKey;column:document_id" json:"document_id"`
+        SubmissionID     int        `gorm:"column:submission_id" json:"submission_id"`
+        FileID           int        `gorm:"column:file_id" json:"file_id"`
+        DocumentTypeID   int        `gorm:"column:document_type_id" json:"document_type_id"`
 	DocumentTypeName string     `gorm:"->;column:document_type_name" json:"document_type_name"`
 	Description      string     `gorm:"column:description" json:"description"`
 	DisplayOrder     int        `gorm:"column:display_order" json:"display_order"`
@@ -145,8 +149,23 @@ type SubmissionDocument struct {
 	// Relations
 	Submission   Submission   `gorm:"foreignKey:SubmissionID" json:"submission,omitempty"`
 	File         FileUpload   `gorm:"foreignKey:FileID" json:"file,omitempty"`
-	DocumentType DocumentType `gorm:"foreignKey:DocumentTypeID" json:"document_type,omitempty"`
-	Verifier     *User        `gorm:"foreignKey:VerifiedBy" json:"verifier,omitempty"`
+        DocumentType DocumentType `gorm:"foreignKey:DocumentTypeID" json:"document_type,omitempty"`
+        Verifier     *User        `gorm:"foreignKey:VerifiedBy" json:"verifier,omitempty"`
+}
+
+type SubmissionStatusHistory struct {
+        HistoryID    int        `gorm:"primaryKey;column:history_id" json:"history_id"`
+        SubmissionID int        `gorm:"column:submission_id" json:"submission_id"`
+        OldStatusID  *int       `gorm:"column:old_status_id" json:"old_status_id,omitempty"`
+        NewStatusID  int        `gorm:"column:new_status_id" json:"new_status_id"`
+        ChangedBy    int        `gorm:"column:changed_by" json:"changed_by"`
+        Reason       *string    `gorm:"column:reason" json:"reason,omitempty"`
+        Notes        *string    `gorm:"column:notes" json:"notes,omitempty"`
+        CreatedAt    time.Time  `gorm:"column:created_at" json:"created_at"`
+}
+
+func (SubmissionStatusHistory) TableName() string {
+        return "submission_status_history"
 }
 
 // SubmissionUser represents co-authors and collaborators in submissions
@@ -193,7 +212,7 @@ func (s *Submission) IsEditable() bool {
 }
 
 func (s *Submission) CanBeSubmitted() bool {
-	return s.StatusID == 1 && s.SubmittedAt == nil
+        return s.SubmittedAt == nil
 }
 
 func (s *Submission) IsSubmitted() bool {

--- a/fund-management-api/routes/routes.go
+++ b/fund-management-api/routes/routes.go
@@ -148,13 +148,21 @@ func SetupRoutes(router *gin.Engine) {
 			}
 
 			// Staff-specific endpoints
-			staff := protected.Group("/staff")
-			{
-				// ใช้ function เดียวกัน
-				staff.GET("/subcategories", controllers.GetSubcategoryForRole)
-				staff.GET("/submissions", controllers.GetStaffSubmissions) // Staff ดู submissions ของตัวเอง
-				staff.GET("/dashboard/stats", controllers.GetDashboardStats)
-			}
+                        staff := protected.Group("/staff")
+                        {
+                                // ใช้ function เดียวกัน
+                                staff.GET("/subcategories", controllers.GetSubcategoryForRole)
+                                staff.GET("/submissions", controllers.GetStaffSubmissions) // Staff ดู submissions ของตัวเอง
+                                staff.GET("/dashboard/stats", controllers.GetDashboardStats)
+                        }
+
+                        deptHead := protected.Group("/dept-head")
+                        {
+                                deptHead.Use(middleware.RequireRole(4))
+                                deptHead.GET("/submissions", controllers.GetDeptHeadSubmissions)
+                                deptHead.POST("/submissions/:id/recommend", controllers.DeptHeadRecommendSubmission)
+                                deptHead.POST("/submissions/:id/reject", controllers.DeptHeadRejectSubmission)
+                        }
 
 			// Fund Applications
 			applications := protected.Group("/applications")

--- a/fund-management-api/utils/status_resolver.go
+++ b/fund-management-api/utils/status_resolver.go
@@ -1,0 +1,63 @@
+package utils
+
+import (
+    "fmt"
+    "strings"
+
+    "fund-management-api/config"
+    "fund-management-api/models"
+)
+
+// FetchApplicationStatuses returns all status records from database.
+func FetchApplicationStatuses() ([]models.ApplicationStatus, error) {
+    var statuses []models.ApplicationStatus
+    if err := config.DB.Find(&statuses).Error; err != nil {
+        return nil, err
+    }
+    return statuses, nil
+}
+
+// ResolveStatusesByLabels returns a map of label -> status record, matching by substring.
+func ResolveStatusesByLabels(labels []string) (map[string]models.ApplicationStatus, error) {
+    if len(labels) == 0 {
+        return map[string]models.ApplicationStatus{}, nil
+    }
+
+    statuses, err := FetchApplicationStatuses()
+    if err != nil {
+        return nil, err
+    }
+
+    result := make(map[string]models.ApplicationStatus, len(labels))
+    for _, label := range labels {
+        matched := []models.ApplicationStatus{}
+        for _, status := range statuses {
+            if strings.Contains(status.StatusName, label) {
+                matched = append(matched, status)
+            }
+        }
+
+        if len(matched) == 0 {
+            return nil, fmt.Errorf("status containing %q not found", label)
+        }
+        if len(matched) > 1 {
+            return nil, fmt.Errorf("multiple statuses matched label %q", label)
+        }
+        result[label] = matched[0]
+    }
+
+    return result, nil
+}
+
+// ResolveStatusIDByLabel resolves a single status ID by matching the status name substring.
+func ResolveStatusIDByLabel(label string) (int, error) {
+    records, err := ResolveStatusesByLabels([]string{label})
+    if err != nil {
+        return 0, err
+    }
+    status, ok := records[label]
+    if !ok {
+        return 0, fmt.Errorf("status containing %q not found", label)
+    }
+    return status.ApplicationStatusID, nil
+}


### PR DESCRIPTION
## Summary
- add shared frontend status lookup helper and use it when teachers submit fund or publication requests so new submissions enter the department-head pending state
- introduce backend utilities and department-head endpoints to resolve status IDs dynamically, capture recommendations/rejections, and prevent admins from bypassing the new gate
- update admin submission UIs (general and publication) to fetch statuses, respect the department-head guard, and surface read-only or notice states when waiting on or after department review

## Testing
- npm run lint *(fails: command prompts for interactive ESLint config)*
- go test ./... *(fails: command hangs while resolving modules)*

------
https://chatgpt.com/codex/tasks/task_e_68d14b95da04832285a09cf3aab4c2d5