### PR TITLE
Fix publication reward submission status handling

### DIFF
--- a/frontend_project_fund/app/member/components/applications/PublicationRewardForm.js
+++ b/frontend_project_fund/app/member/components/applications/PublicationRewardForm.js
@@ -22,7 +22,6 @@ import { PDFDocument } from 'pdf-lib';
 import { notificationsAPI } from '../../../lib/notifications_api';
 import { systemConfigAPI } from '../../../lib/system_config_api';
 import { getAuthorSubmissionFields } from './PublicationRewardForm.helpers.mjs';
-import { getStatusIdByName } from '../../../lib/status_service';
 
 // =================================================================
 // CONFIGURATION & CONSTANTS
@@ -2292,19 +2291,12 @@ const showSubmissionConfirmation = async () => {
           subcategory_budget_id: formData.subcategory_budget_id
         });
 
-        // ใน submitApplication function - เพิ่ม validation และ submission data
-        const deptPendingStatusId = await getStatusIdByName('อยู่ระหว่างการพิจารณาจากหัวหน้าสาขา');
-        if (!deptPendingStatusId) {
-          throw new Error('ไม่พบสถานะ "อยู่ระหว่างการพิจารณาจากหัวหน้าสาขา"');
-        }
-
         const submissionResponse = await submissionAPI.create({
           submission_type: 'publication_reward',
           year_id: formData.year_id,
           category_id: formData.category_id || categoryId,
           subcategory_id: formData.subcategory_id,        // Dynamic resolved
           subcategory_budget_id: formData.subcategory_budget_id,  // Dynamic resolved
-          status_id: deptPendingStatusId,
         });
         
         submissionId = submissionResponse.submission.submission_id;

--- a/fund-management-api/controllers/admin_submission.go
+++ b/fund-management-api/controllers/admin_submission.go
@@ -4,6 +4,7 @@ package controllers
 import (
 	"fund-management-api/config"
 	"fund-management-api/models"
+	"fund-management-api/utils"
 	"net/http"
 	"strconv"
 	"strings"
@@ -277,10 +278,21 @@ func ApproveSubmission(c *gin.Context) {
 		return
 	}
 
-	// Validate status (1=pending, 4=revision requested)
-	if submission.StatusID != 1 && submission.StatusID != 4 {
+	allowedForApproval, err := utils.StatusMatchesCodes(
+		submission.StatusID,
+		utils.StatusCodePending,
+		utils.StatusCodeDraft,
+		utils.StatusCodeDeptHeadPending,
+		utils.StatusCodeDeptHeadRecommended,
+	)
+	if err != nil {
 		tx.Rollback()
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Only pending or revision-requested submissions can be approved"})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to verify submission status"})
+		return
+	}
+	if !allowedForApproval {
+		tx.Rollback()
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Only submissions awaiting review can be approved"})
 		return
 	}
 
@@ -406,10 +418,22 @@ func RejectSubmission(c *gin.Context) {
 		return
 	}
 
-	// Only pending (1) or revision-requested (4) can be rejected
-	if submission.StatusID != 1 && submission.StatusID != 4 {
+	allowedForRejection, err := utils.StatusMatchesCodes(
+		submission.StatusID,
+		utils.StatusCodePending,
+		utils.StatusCodeDraft,
+		utils.StatusCodeDeptHeadPending,
+		utils.StatusCodeDeptHeadRecommended,
+		utils.StatusCodeDeptHeadNotRecommended,
+	)
+	if err != nil {
 		tx.Rollback()
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Only pending or revision-requested submissions can be rejected"})
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to verify submission status"})
+		return
+	}
+	if !allowedForRejection {
+		tx.Rollback()
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Only submissions awaiting review can be rejected"})
 		return
 	}
 

--- a/fund-management-api/models/submission.go
+++ b/fund-management-api/models/submission.go
@@ -191,11 +191,11 @@ func (SubmissionDocument) TableName() string {
 
 // Helper methods for Submission
 func (s *Submission) IsEditable() bool {
-	return s.StatusID == 1 && s.SubmittedAt == nil // Only draft status and not submitted
+	return s.SubmittedAt == nil
 }
 
 func (s *Submission) CanBeSubmitted() bool {
-	return s.StatusID == 1 && s.SubmittedAt == nil
+	return s.SubmittedAt == nil
 }
 
 func (s *Submission) IsSubmitted() bool {

--- a/fund-management-api/utils/status_lookup.go
+++ b/fund-management-api/utils/status_lookup.go
@@ -1,0 +1,130 @@
+package utils
+
+import (
+	"fmt"
+	"sync"
+
+	"fund-management-api/config"
+	"fund-management-api/models"
+
+	"gorm.io/gorm"
+)
+
+const (
+	StatusCodePending                = "0"
+	StatusCodeApproved               = "1"
+	StatusCodeRejected               = "2"
+	StatusCodeNeedsMoreInfo          = "3"
+	StatusCodeDraft                  = "4"
+	StatusCodeDeptHeadPending        = "5"
+	StatusCodeDeptHeadRecommended    = "6"
+	StatusCodeDeptHeadNotRecommended = "7"
+)
+
+type statusCache struct {
+	sync.RWMutex
+	byCode map[string]models.ApplicationStatus
+	byID   map[int]models.ApplicationStatus
+}
+
+var applicationStatusCache = statusCache{
+	byCode: make(map[string]models.ApplicationStatus),
+	byID:   make(map[int]models.ApplicationStatus),
+}
+
+func cacheStatus(status models.ApplicationStatus) {
+	applicationStatusCache.Lock()
+	defer applicationStatusCache.Unlock()
+
+	if status.ApplicationStatusID != 0 {
+		applicationStatusCache.byID[status.ApplicationStatusID] = status
+	}
+	if status.StatusCode != "" {
+		applicationStatusCache.byCode[status.StatusCode] = status
+	}
+}
+
+func getCachedStatusByCode(code string) (models.ApplicationStatus, bool) {
+	applicationStatusCache.RLock()
+	defer applicationStatusCache.RUnlock()
+
+	status, ok := applicationStatusCache.byCode[code]
+	return status, ok && status.ApplicationStatusID != 0
+}
+
+func getCachedStatusByID(id int) (models.ApplicationStatus, bool) {
+	applicationStatusCache.RLock()
+	defer applicationStatusCache.RUnlock()
+
+	status, ok := applicationStatusCache.byID[id]
+	return status, ok && status.ApplicationStatusID != 0
+}
+
+func GetApplicationStatusByCode(code string) (models.ApplicationStatus, error) {
+	if status, ok := getCachedStatusByCode(code); ok {
+		return status, nil
+	}
+
+	var status models.ApplicationStatus
+	err := config.DB.Where("status_code = ? AND (delete_at IS NULL)", code).First(&status).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return models.ApplicationStatus{}, fmt.Errorf("application status with code %s not found", code)
+		}
+		return models.ApplicationStatus{}, err
+	}
+
+	cacheStatus(status)
+	return status, nil
+}
+
+func GetApplicationStatusByID(id int) (models.ApplicationStatus, error) {
+	if status, ok := getCachedStatusByID(id); ok {
+		return status, nil
+	}
+
+	var status models.ApplicationStatus
+	err := config.DB.Where("application_status_id = ? AND (delete_at IS NULL)", id).First(&status).Error
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return models.ApplicationStatus{}, fmt.Errorf("application status with id %d not found", id)
+		}
+		return models.ApplicationStatus{}, err
+	}
+
+	cacheStatus(status)
+	return status, nil
+}
+
+func GetStatusIDByCode(code string) (int, error) {
+	status, err := GetApplicationStatusByCode(code)
+	if err != nil {
+		return 0, err
+	}
+	return status.ApplicationStatusID, nil
+}
+
+func GetStatusIDsByCodes(codes ...string) ([]int, error) {
+	ids := make([]int, 0, len(codes))
+	for _, code := range codes {
+		id, err := GetStatusIDByCode(code)
+		if err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
+func StatusMatchesCodes(statusID int, codes ...string) (bool, error) {
+	status, err := GetApplicationStatusByID(statusID)
+	if err != nil {
+		return false, err
+	}
+	for _, code := range codes {
+		if status.StatusCode == code {
+			return true, nil
+		}
+	}
+	return false, nil
+}


### PR DESCRIPTION
## Summary
- add reusable application status lookup utilities to resolve IDs from the database
- set the initial submission status via the lookup service and treat department-review statuses as editable/submittable
- include department pending statuses in dashboard/admin flows and stop the publication reward form from hard-coding a status id

## Testing
- `go test ./...` *(fails: command hangs, interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68d27ebf4d74832abae121ece06baafc