### PR TITLE
Ensure publication reward submissions use resolved subcategory

### DIFF
--- a/frontend_project_fund/app/member/components/applications/PublicationRewardForm.js
+++ b/frontend_project_fund/app/member/components/applications/PublicationRewardForm.js
@@ -2312,7 +2312,7 @@ const showSubmissionConfirmation = async () => {
       const resolvedBudgetId = Number(freshResolution.subcategory_budget_id);
       const rewardAmountSource = freshResolution.reward_amount ?? freshResolution.amount ?? 0;
       const parsedRewardAmount = Number(rewardAmountSource);
-      const resolvedRewardAmount = Number.isFinite(parsedRewardAmount) ? parsedRewardAmount : 0;
+      const resolvedRewardValue = Number.isFinite(parsedRewardAmount) ? parsedRewardAmount : 0;
 
       if (!Number.isInteger(resolvedSubcategoryId) || !Number.isInteger(resolvedBudgetId)) {
         throw new Error('ข้อมูลหมวดทุนไม่ถูกต้อง');
@@ -2321,7 +2321,7 @@ const showSubmissionConfirmation = async () => {
       resolvedRewardContext = {
         subcategoryId: resolvedSubcategoryId,
         budgetId: resolvedBudgetId,
-        rewardAmount: resolvedRewardAmount
+        rewardAmount: resolvedRewardValue
       };
 
       // Sync state to the latest resolved values for downstream logic/debugging
@@ -2329,14 +2329,14 @@ const showSubmissionConfirmation = async () => {
         ...prev,
         subcategory_id: resolvedSubcategoryId,
         subcategory_budget_id: resolvedBudgetId,
-        publication_reward: resolvedRewardAmount,
-        reward_amount: resolvedRewardAmount
+        publication_reward: resolvedRewardValue,
+        reward_amount: resolvedRewardValue
       }));
 
       console.log('Resolved mapping before submission:', {
         resolvedSubcategoryId,
         resolvedBudgetId,
-        resolvedRewardAmount
+        resolvedRewardValue
       });
 
       if (!submissionId) {
@@ -2530,7 +2530,10 @@ const showSubmissionConfirmation = async () => {
 
       const authorSubmissionFields = getAuthorSubmissionFields(formData);
 
-      const resolvedRewardAmount = resolvedRewardContext?.rewardAmount;
+      const finalResolvedRewardAmount =
+        resolvedRewardContext?.rewardAmount ??
+        resolvedRewardValue ??
+        (parseFloat(formData.publication_reward) || 0);
 
       const publicationData = {
         // Basic article info
@@ -2556,7 +2559,7 @@ const showSubmissionConfirmation = async () => {
         ].filter(Boolean).join(', ') || '',
         
         // Financial fields
-        reward_amount: resolvedRewardAmount ?? (parseFloat(formData.publication_reward) || 0),
+        reward_amount: finalResolvedRewardAmount,
         revision_fee: parseFloat(formData.revision_fee) || 0,
         publication_fee: parseFloat(formData.publication_fee) || 0,
         external_funding_amount: parseFloat(formData.external_funding_amount) || 0,

--- a/frontend_project_fund/app/member/components/applications/PublicationRewardForm.js
+++ b/frontend_project_fund/app/member/components/applications/PublicationRewardForm.js
@@ -2282,54 +2282,66 @@ const showSubmissionConfirmation = async () => {
 
       console.log(`Total files to upload: ${allFiles.length}`);
 
-      // Create submission if not exists
+      const rawCategoryId = formData.category_id ?? categoryId;
+      if (!rawCategoryId) {
+        throw new Error('ไม่พบหมวดหมู่ของคำร้อง');
+      }
+
+      const resolvedCategoryId = Number(rawCategoryId);
+      if (!Number.isInteger(resolvedCategoryId)) {
+        throw new Error('หมวดหมู่ของคำร้องไม่ถูกต้อง');
+      }
+
+      Swal.update({
+        html: submissionId ? 'กำลังตรวจสอบและอัปเดตข้อมูลทุน...' : 'กำลังตรวจสอบข้อมูลทุน...'
+      });
+
+      // Re-resolve the budget/subcategory pairing to ensure we submit the latest mapping
+      const freshResolution = await resolveBudgetAndSubcategory({
+        category_id: resolvedCategoryId,
+        year_id: formData.year_id,
+        author_status: formData.author_status,
+        journal_quartile: formData.journal_quartile
+      });
+
+      if (!freshResolution || !freshResolution.subcategory_id || !freshResolution.subcategory_budget_id) {
+        throw new Error('ไม่สามารถระบุหมวดทุนที่สอดคล้องได้');
+      }
+
+      const resolvedSubcategoryId = Number(freshResolution.subcategory_id);
+      const resolvedBudgetId = Number(freshResolution.subcategory_budget_id);
+      const rewardAmountSource = freshResolution.reward_amount ?? freshResolution.amount ?? 0;
+      const parsedRewardAmount = Number(rewardAmountSource);
+      const resolvedRewardAmount = Number.isFinite(parsedRewardAmount) ? parsedRewardAmount : 0;
+
+      if (!Number.isInteger(resolvedSubcategoryId) || !Number.isInteger(resolvedBudgetId)) {
+        throw new Error('ข้อมูลหมวดทุนไม่ถูกต้อง');
+      }
+
+      resolvedRewardContext = {
+        subcategoryId: resolvedSubcategoryId,
+        budgetId: resolvedBudgetId,
+        rewardAmount: resolvedRewardAmount
+      };
+
+      // Sync state to the latest resolved values for downstream logic/debugging
+      setFormData(prev => ({
+        ...prev,
+        subcategory_id: resolvedSubcategoryId,
+        subcategory_budget_id: resolvedBudgetId,
+        publication_reward: resolvedRewardAmount,
+        reward_amount: resolvedRewardAmount
+      }));
+
+      console.log('Resolved mapping before submission:', {
+        resolvedSubcategoryId,
+        resolvedBudgetId,
+        resolvedRewardAmount
+      });
+
       if (!submissionId) {
         Swal.update({
           html: 'กำลังสร้างคำร้อง...'
-        });
-
-        console.log('Before POST:', {
-          subcategory_id: formData.subcategory_id,
-          subcategory_budget_id: formData.subcategory_budget_id
-        });
-
-        // Re-resolve the budget/subcategory pairing to ensure we submit the latest mapping
-        const freshResolution = await resolveBudgetAndSubcategory({
-          category_id: formData.category_id || categoryId,
-          year_id: formData.year_id,
-          author_status: formData.author_status,
-          journal_quartile: formData.journal_quartile
-        });
-
-        if (!freshResolution || !freshResolution.subcategory_id || !freshResolution.subcategory_budget_id) {
-          throw new Error('ไม่สามารถระบุหมวดทุนที่สอดคล้องได้');
-        }
-
-        const resolvedSubcategoryId = Number(freshResolution.subcategory_id);
-        const resolvedBudgetId = Number(freshResolution.subcategory_budget_id);
-        const resolvedRewardAmount = Number(
-          freshResolution.reward_amount ?? freshResolution.amount ?? 0
-        );
-
-        resolvedRewardContext = {
-          subcategoryId: resolvedSubcategoryId,
-          budgetId: resolvedBudgetId,
-          rewardAmount: resolvedRewardAmount
-        };
-
-        // Sync state to the latest resolved values for downstream logic/debugging
-        setFormData(prev => ({
-          ...prev,
-          subcategory_id: resolvedSubcategoryId,
-          subcategory_budget_id: resolvedBudgetId,
-          publication_reward: resolvedRewardAmount,
-          reward_amount: resolvedRewardAmount
-        }));
-
-        console.log('Resolved mapping before submission:', {
-          resolvedSubcategoryId,
-          resolvedBudgetId,
-          resolvedRewardAmount
         });
 
         // ใน submitApplication function - เพิ่ม validation และ submission data
@@ -2341,7 +2353,7 @@ const showSubmissionConfirmation = async () => {
         const submissionResponse = await submissionAPI.create({
           submission_type: 'publication_reward',
           year_id: formData.year_id,
-          category_id: formData.category_id || categoryId,
+          category_id: resolvedCategoryId,
           subcategory_id: resolvedSubcategoryId,        // Dynamic resolved
           subcategory_budget_id: resolvedBudgetId,  // Dynamic resolved
           status_id: deptPendingStatusId,
@@ -2350,6 +2362,31 @@ const showSubmissionConfirmation = async () => {
         submissionId = submissionResponse.submission.submission_id;
         setCurrentSubmissionId(submissionId);
         console.log('Created submission:', submissionId);
+      } else {
+        Swal.update({
+          html: 'กำลังอัปเดตข้อมูลคำร้อง...'
+        });
+
+        const updatePayload = {
+          subcategory_id: resolvedSubcategoryId,
+          subcategory_budget_id: resolvedBudgetId
+        };
+
+        if (resolvedCategoryId) {
+          updatePayload.category_id = resolvedCategoryId;
+        }
+
+        try {
+          await submissionAPI.update(submissionId, updatePayload);
+          console.log('Updated submission with resolved mapping:', {
+            submissionId,
+            resolvedSubcategoryId,
+            resolvedBudgetId
+          });
+        } catch (updateError) {
+          console.error('Failed to update submission mapping:', updateError);
+          throw new Error('ไม่สามารถอัปเดตหมวดทุนของคำร้องได้');
+        }
       }
 
       // Step 2: Manage Users in Submission

--- a/frontend_project_fund/app/member/components/applications/PublicationRewardForm.js
+++ b/frontend_project_fund/app/member/components/applications/PublicationRewardForm.js
@@ -2235,6 +2235,7 @@ const showSubmissionConfirmation = async () => {
       let submissionId = currentSubmissionId;
       const allFiles = [];
       const processedFiles = new Set(); // ป้องกันไฟล์ซ้ำ
+      let resolvedRewardContext = null;
 
       // 1. Add main document files (document_type_id 1-10)
       Object.entries(uploadedFiles).forEach(([docTypeId, file]) => {
@@ -2306,17 +2307,29 @@ const showSubmissionConfirmation = async () => {
 
         const resolvedSubcategoryId = Number(freshResolution.subcategory_id);
         const resolvedBudgetId = Number(freshResolution.subcategory_budget_id);
+        const resolvedRewardAmount = Number(
+          freshResolution.reward_amount ?? freshResolution.amount ?? 0
+        );
+
+        resolvedRewardContext = {
+          subcategoryId: resolvedSubcategoryId,
+          budgetId: resolvedBudgetId,
+          rewardAmount: resolvedRewardAmount
+        };
 
         // Sync state to the latest resolved values for downstream logic/debugging
         setFormData(prev => ({
           ...prev,
           subcategory_id: resolvedSubcategoryId,
-          subcategory_budget_id: resolvedBudgetId
+          subcategory_budget_id: resolvedBudgetId,
+          publication_reward: resolvedRewardAmount,
+          reward_amount: resolvedRewardAmount
         }));
 
         console.log('Resolved mapping before submission:', {
           resolvedSubcategoryId,
-          resolvedBudgetId
+          resolvedBudgetId,
+          resolvedRewardAmount
         });
 
         // ใน submitApplication function - เพิ่ม validation และ submission data
@@ -2333,7 +2346,7 @@ const showSubmissionConfirmation = async () => {
           subcategory_budget_id: resolvedBudgetId,  // Dynamic resolved
           status_id: deptPendingStatusId,
         });
-        
+
         submissionId = submissionResponse.submission.submission_id;
         setCurrentSubmissionId(submissionId);
         console.log('Created submission:', submissionId);
@@ -2480,6 +2493,8 @@ const showSubmissionConfirmation = async () => {
 
       const authorSubmissionFields = getAuthorSubmissionFields(formData);
 
+      const resolvedRewardAmount = resolvedRewardContext?.rewardAmount;
+
       const publicationData = {
         // Basic article info
         article_title: formData.article_title || '',
@@ -2504,7 +2519,7 @@ const showSubmissionConfirmation = async () => {
         ].filter(Boolean).join(', ') || '',
         
         // Financial fields
-        reward_amount: parseFloat(formData.publication_reward) || 0,
+        reward_amount: resolvedRewardAmount ?? (parseFloat(formData.publication_reward) || 0),
         revision_fee: parseFloat(formData.revision_fee) || 0,
         publication_fee: parseFloat(formData.publication_fee) || 0,
         external_funding_amount: parseFloat(formData.external_funding_amount) || 0,

--- a/frontend_project_fund/app/member/components/applications/PublicationRewardForm.js
+++ b/frontend_project_fund/app/member/components/applications/PublicationRewardForm.js
@@ -2292,6 +2292,33 @@ const showSubmissionConfirmation = async () => {
           subcategory_budget_id: formData.subcategory_budget_id
         });
 
+        // Re-resolve the budget/subcategory pairing to ensure we submit the latest mapping
+        const freshResolution = await resolveBudgetAndSubcategory({
+          category_id: formData.category_id || categoryId,
+          year_id: formData.year_id,
+          author_status: formData.author_status,
+          journal_quartile: formData.journal_quartile
+        });
+
+        if (!freshResolution || !freshResolution.subcategory_id || !freshResolution.subcategory_budget_id) {
+          throw new Error('ไม่สามารถระบุหมวดทุนที่สอดคล้องได้');
+        }
+
+        const resolvedSubcategoryId = Number(freshResolution.subcategory_id);
+        const resolvedBudgetId = Number(freshResolution.subcategory_budget_id);
+
+        // Sync state to the latest resolved values for downstream logic/debugging
+        setFormData(prev => ({
+          ...prev,
+          subcategory_id: resolvedSubcategoryId,
+          subcategory_budget_id: resolvedBudgetId
+        }));
+
+        console.log('Resolved mapping before submission:', {
+          resolvedSubcategoryId,
+          resolvedBudgetId
+        });
+
         // ใน submitApplication function - เพิ่ม validation และ submission data
         const deptPendingStatusId = await getStatusIdByName('อยู่ระหว่างการพิจารณาจากหัวหน้าสาขา');
         if (!deptPendingStatusId) {
@@ -2302,8 +2329,8 @@ const showSubmissionConfirmation = async () => {
           submission_type: 'publication_reward',
           year_id: formData.year_id,
           category_id: formData.category_id || categoryId,
-          subcategory_id: formData.subcategory_id,        // Dynamic resolved
-          subcategory_budget_id: formData.subcategory_budget_id,  // Dynamic resolved
+          subcategory_id: resolvedSubcategoryId,        // Dynamic resolved
+          subcategory_budget_id: resolvedBudgetId,  // Dynamic resolved
           status_id: deptPendingStatusId,
         });
         


### PR DESCRIPTION
## Summary
- re-resolve the publication reward subcategory mapping immediately before creating a submission so the stored subcategory_id matches the selected budget
- synchronise the resolved identifiers into form state for debugging and downstream logic

## Testing
- npm run lint *(fails: prompts to configure ESLint interactively)*

------
https://chatgpt.com/codex/tasks/task_e_68d28c211ba0832aba0c0166e8445be4