### PR TITLE
Fix publication reward subcategory id mismatch

### DIFF
--- a/frontend_project_fund/app/lib/publication_api.js
+++ b/frontend_project_fund/app/lib/publication_api.js
@@ -10,6 +10,23 @@ const getAuthHeaders = () => {
   };
 };
 
+const normalizeNumericField = (value) => {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  if (typeof value === 'number') {
+    return Number.isNaN(value) ? null : Math.trunc(value);
+  }
+
+  const parsed = Number(value);
+  if (Number.isNaN(parsed)) {
+    return null;
+  }
+
+  return Math.trunc(parsed);
+};
+
 // Submission Management API (ตาม API docs)
 export const submissionAPI = {
   // Create new submission
@@ -19,9 +36,18 @@ export const submissionAPI = {
         submission_type: data.submission_type,
         year_id: data.year_id,
       };
-      if (data.category_id) payload.category_id = data.category_id;
-      if (data.subcategory_id) payload.subcategory_id = data.subcategory_id;
-      if (data.subcategory_budget_id) payload.subcategory_budget_id = data.subcategory_budget_id;
+      const normalizedCategoryId = normalizeNumericField(data.category_id);
+      if (normalizedCategoryId !== null) {
+        payload.category_id = normalizedCategoryId;
+      }
+      const normalizedSubcategoryId = normalizeNumericField(data.subcategory_id);
+      if (normalizedSubcategoryId !== null) {
+        payload.subcategory_id = normalizedSubcategoryId;
+      }
+      const normalizedBudgetId = normalizeNumericField(data.subcategory_budget_id);
+      if (normalizedBudgetId !== null) {
+        payload.subcategory_budget_id = normalizedBudgetId;
+      }
       if (data.status_id != null) payload.status_id = data.status_id;
 
       const response = await apiClient.post('/submissions', payload);

--- a/frontend_project_fund/app/member/components/applications/PublicationRewardForm.js
+++ b/frontend_project_fund/app/member/components/applications/PublicationRewardForm.js
@@ -104,10 +104,25 @@ const sortQuartiles = (quartiles) => {
   });
 };
 
+// Normalize numeric identifier values that may come as strings
+const normalizeIdValue = (value) => {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  const numericValue = typeof value === 'number' ? value : Number(value);
+
+  if (Number.isNaN(numericValue)) {
+    return null;
+  }
+
+  return Math.trunc(numericValue);
+};
+
 // Get maximum fee limit based on quartile
 const getMaxFeeLimit = async (quartile, year = null) => {
   if (!quartile) return 0;
-  
+
   try {
     // หา year (พ.ศ.) จาก year_id หรือใช้ปีปัจจุบัน + 543
     const currentYear = new Date().getFullYear() + 543;
@@ -801,8 +816,8 @@ export default function PublicationRewardForm({ onNavigate, categoryId, yearId, 
           if (result) {
             setFormData(prev => ({
               ...prev,
-              subcategory_id: result.subcategory_id,
-              subcategory_budget_id: result.subcategory_budget_id,
+              subcategory_id: normalizeIdValue(result.subcategory_id),
+              subcategory_budget_id: normalizeIdValue(result.subcategory_budget_id),
               publication_reward: result.reward_amount,
               reward_amount: result.reward_amount,
             }));
@@ -2286,19 +2301,48 @@ const showSubmissionConfirmation = async () => {
           html: 'กำลังสร้างคำร้อง...'
         });
 
+        const targetCategoryId = formData.category_id || categoryId;
+        let resolvedSubcategoryId = normalizeIdValue(formData.subcategory_id);
+        let resolvedSubcategoryBudgetId = normalizeIdValue(formData.subcategory_budget_id);
+
+        if (targetCategoryId && formData.author_status && formData.journal_quartile && formData.year_id) {
+          try {
+            const resolution = await resolveBudgetAndSubcategory({
+              category_id: targetCategoryId,
+              year_id: formData.year_id,
+              author_status: formData.author_status,
+              journal_quartile: formData.journal_quartile
+            });
+
+            if (resolution) {
+              const resolutionSubId = normalizeIdValue(resolution.subcategory_id);
+              const resolutionBudgetId = normalizeIdValue(resolution.subcategory_budget_id);
+
+              if (resolutionSubId !== null && resolutionBudgetId !== null) {
+                resolvedSubcategoryId = resolutionSubId;
+                resolvedSubcategoryBudgetId = resolutionBudgetId;
+              } else {
+                console.warn('Resolved budget missing IDs, falling back to form data', resolution);
+              }
+            }
+          } catch (resolveError) {
+            console.error('Failed to resolve subcategory before submission:', resolveError);
+          }
+        }
+
         console.log('Before POST:', {
-          subcategory_id: formData.subcategory_id,
-          subcategory_budget_id: formData.subcategory_budget_id
+          subcategory_id: resolvedSubcategoryId,
+          subcategory_budget_id: resolvedSubcategoryBudgetId
         });
 
         const submissionResponse = await submissionAPI.create({
           submission_type: 'publication_reward',
           year_id: formData.year_id,
-          category_id: formData.category_id || categoryId,
-          subcategory_id: formData.subcategory_id,        // Dynamic resolved
-          subcategory_budget_id: formData.subcategory_budget_id,  // Dynamic resolved
+          category_id: targetCategoryId,
+          subcategory_id: resolvedSubcategoryId,
+          subcategory_budget_id: resolvedSubcategoryBudgetId,
         });
-        
+
         submissionId = submissionResponse.submission.submission_id;
         setCurrentSubmissionId(submissionId);
         console.log('Created submission:', submissionId);


### PR DESCRIPTION
## Summary
- normalize resolved subcategory and subcategory budget identifiers before submitting publication reward forms
- re-resolve the active budget prior to submission creation so the stored IDs always correspond to each other
- sanitize numeric identifiers in the shared submission API helper before posting to the backend

## Testing
- npm run lint *(fails: Next.js prompts to scaffold an ESLint config in this project)*

------
https://chatgpt.com/codex/tasks/task_e_68d2a6b9200c832aafff5507a4f1f667