### PR TITLE
Adjust dept head review workflow for new statuses

### DIFF
--- a/frontend_project_fund/app/lib/dept_status_labels.js
+++ b/frontend_project_fund/app/lib/dept_status_labels.js
@@ -1,7 +1,10 @@
 export const DEPT_STATUS_LABELS = {
   pending: 'อยู่ระหว่างการพิจารณาจากหัวหน้าสาขา',
-  recommended: 'เห็นควรพิจารณาจากหัวหน้าสาขา',
+  forwarded: 'อยู่ระหว่างการพิจารณา',
   rejected: 'ไม่เห็นควรพิจารณา',
+  // Backward compatibility: some legacy code may still reference "recommended"
+  // which previously mapped to the department head approval outcome.
+  recommended: 'อยู่ระหว่างการพิจารณา',
 };
 
 export function getDeptStatusLabels() {

--- a/frontend_project_fund/app/lib/dept_status_labels.js
+++ b/frontend_project_fund/app/lib/dept_status_labels.js
@@ -4,7 +4,7 @@ export const DEPT_STATUS_LABELS = {
   rejected: 'ไม่เห็นควรพิจารณา',
   // Backward compatibility: some legacy code may still reference "recommended"
   // which previously mapped to the department head approval outcome.
-  recommended: 'อยู่ระหว่างการพิจารณา',
+  recommended: 'เห็นควรพิจารณาจากหัวหน้าสาขา',
 };
 
 export function getDeptStatusLabels() {

--- a/frontend_project_fund/app/member/components/dept/DeptHeadReview.js
+++ b/frontend_project_fund/app/member/components/dept/DeptHeadReview.js
@@ -24,11 +24,6 @@ const formatDate = (value) => {
   }
 };
 
-const DECISION_MAP = {
-  recommend: "agree",
-  reject: "disagree",
-};
-
 export default function DeptHeadReview() {
   const { getByName, isLoading: statusLoading } = useStatusMap();
 
@@ -51,23 +46,27 @@ export default function DeptHeadReview() {
     };
 
     const pending = getByName?.(DEPT_STATUS_LABELS.pending);
-    const recommended = getByName?.(DEPT_STATUS_LABELS.recommended);
+    const forwarded =
+      getByName?.(DEPT_STATUS_LABELS.forwarded) ||
+      getByName?.(DEPT_STATUS_LABELS.recommended);
     const rejected = getByName?.(DEPT_STATUS_LABELS.rejected);
 
     const pendingId = parseId(pending);
-    const recommendedId = parseId(recommended);
+    const forwardedId = parseId(forwarded);
     const rejectedId = parseId(rejected);
 
     return {
       pendingId,
-      recommendedId,
+      forwardedId,
       rejectedId,
-      ready: Boolean(pendingId && recommendedId && rejectedId),
+      ready: Boolean(pendingId && forwardedId && rejectedId),
     };
   }, [getByName]);
 
   const statusesReady = statusInfo.ready;
   const pendingStatusId = statusInfo.pendingId;
+  const forwardedStatusId = statusInfo.forwardedId;
+  const rejectedStatusId = statusInfo.rejectedId;
 
   useEffect(() => {
     if (!statusLoading) {
@@ -90,7 +89,10 @@ export default function DeptHeadReview() {
       setLoading(true);
       setError(null);
 
-      const response = await deptHeadAPI.getPendingReviews({ status: "pending" });
+      const response = await deptHeadAPI.getPendingReviews({
+        status_id: pendingStatusId,
+        status: pendingStatusId,
+      });
       const rows = response?.submissions || response?.data || [];
 
       const normalized = rows
@@ -132,12 +134,7 @@ export default function DeptHeadReview() {
             raw: item,
           };
         })
-        .filter((row) => {
-          if (!Number.isFinite(row.statusId)) {
-            return true;
-          }
-          return row.statusId === pendingStatusId;
-        });
+        .filter((row) => Number.isFinite(row.statusId) && row.statusId === pendingStatusId);
 
       setSubmissions(normalized);
     } catch (err) {
@@ -175,12 +172,24 @@ export default function DeptHeadReview() {
       return;
     }
 
+    const isApprove = actionTarget.action === "approve";
+    const nextStatusId = isApprove ? forwardedStatusId : rejectedStatusId;
+
+    if (!Number.isFinite(nextStatusId)) {
+      setActionError("ไม่สามารถระบุสถานะถัดไปได้");
+      return;
+    }
+
     setActionLoading(true);
     setActionError(null);
 
     try {
-      const decision = DECISION_MAP[actionTarget.action] || actionTarget.action;
-      const payload = { decision };
+      const payload = {
+        decision: isApprove ? "approve" : "reject",
+        status_id: nextStatusId,
+        application_status_id: nextStatusId,
+        status: nextStatusId,
+      };
       const trimmed = actionComment.trim();
       if (trimmed) {
         payload.comment = trimmed;
@@ -194,7 +203,15 @@ export default function DeptHeadReview() {
     } finally {
       setActionLoading(false);
     }
-  }, [actionTarget, actionComment, closeAction, loadSubmissions, statusesReady]);
+  }, [
+    actionTarget,
+    actionComment,
+    closeAction,
+    forwardedStatusId,
+    loadSubmissions,
+    rejectedStatusId,
+    statusesReady,
+  ]);
 
   const columns = useMemo(
     () => [
@@ -235,10 +252,10 @@ export default function DeptHeadReview() {
         render: (_, row) => (
           <div className="flex gap-2">
             <button
-              onClick={() => openAction(row, "recommend")}
+              onClick={() => openAction(row, "approve")}
               className="px-3 py-1 text-sm rounded-md border border-blue-200 text-blue-700 hover:bg-blue-50"
             >
-              เห็นควร/ส่งต่อ Admin
+              อนุมัติ
             </button>
             <button
               onClick={() => openAction(row, "reject")}
@@ -270,7 +287,7 @@ export default function DeptHeadReview() {
           <div>
             <h3 className="text-lg font-semibold text-gray-800">รายการคำร้องที่รอตรวจสอบ</h3>
             <p className="text-sm text-gray-500 mt-1">
-              เลือกดำเนินการเพื่อเห็นควรและส่งต่อ หรือปฏิเสธพร้อมระบุเหตุผล
+              เลือกดำเนินการเพื่ออนุมัติหรือปฏิเสธ พร้อมระบุความคิดเห็นประกอบ
             </p>
           </div>
           <button
@@ -310,7 +327,7 @@ export default function DeptHeadReview() {
           <div className="bg-white rounded-xl shadow-xl w-full max-w-lg">
             <div className="px-6 py-4 border-b">
               <h3 className="text-lg font-semibold text-gray-800">
-                {actionTarget.action === "recommend" ? "เห็นควร/ส่งต่อ Admin" : "ปฏิเสธคำร้อง"}
+                {actionTarget.action === "approve" ? "อนุมัติคำร้อง" : "ปฏิเสธคำร้อง"}
               </h3>
               <p className="text-sm text-gray-500 mt-1">
                 เลขคำร้อง {actionTarget.submission_number}
@@ -347,7 +364,7 @@ export default function DeptHeadReview() {
                 onClick={confirmAction}
                 disabled={actionLoading}
                 className={`px-4 py-2 text-sm rounded-md text-white ${
-                  actionTarget.action === "recommend"
+                  actionTarget.action === "approve"
                     ? "bg-blue-600 hover:bg-blue-700"
                     : "bg-red-600 hover:bg-red-700"
                 } disabled:opacity-60`}
@@ -357,8 +374,8 @@ export default function DeptHeadReview() {
                     <Loader2 className="animate-spin" size={16} />
                     กำลังบันทึก...
                   </span>
-                ) : actionTarget.action === "recommend" ? (
-                  "เห็นควร/ส่งต่อ"
+                ) : actionTarget.action === "approve" ? (
+                  "อนุมัติ"
                 ) : (
                   "ปฏิเสธ"
                 )}

--- a/frontend_project_fund/app/member/components/dept/DeptHeadReview.js
+++ b/frontend_project_fund/app/member/components/dept/DeptHeadReview.js
@@ -7,6 +7,7 @@ import Card from "../common/Card";
 import DataTable from "../common/DataTable";
 import StatusBadge from "../common/StatusBadge";
 import { deptHeadAPI } from "../../../lib/member_api";
+import { APIError } from "../../../lib/api";
 import { useStatusMap } from "@/app/hooks/useStatusMap";
 import DEPT_STATUS_LABELS from "@/app/lib/dept_status_labels";
 
@@ -22,6 +23,11 @@ const formatDate = (value) => {
   } catch (error) {
     return value;
   }
+};
+
+const DECISION_MAP = {
+  approve: "agree",
+  reject: "disagree",
 };
 
 export default function DeptHeadReview() {
@@ -89,10 +95,25 @@ export default function DeptHeadReview() {
       setLoading(true);
       setError(null);
 
-      const response = await deptHeadAPI.getPendingReviews({
-        status_id: pendingStatusId,
-        status: pendingStatusId,
-      });
+      let response;
+      const params = { status: "pending_dept" };
+      if (Number.isFinite(pendingStatusId)) {
+        params.status_id = pendingStatusId;
+      }
+
+      try {
+        response = await deptHeadAPI.getPendingReviews(params);
+      } catch (requestError) {
+        const message = requestError?.message?.toLowerCase?.() || "";
+        if (
+          requestError instanceof APIError &&
+          message.includes("invalid status")
+        ) {
+          response = await deptHeadAPI.getPendingReviews({ status: "pending" });
+        } else {
+          throw requestError;
+        }
+      }
       const rows = response?.submissions || response?.data || [];
 
       const normalized = rows
@@ -185,11 +206,13 @@ export default function DeptHeadReview() {
 
     try {
       const payload = {
-        decision: isApprove ? "approve" : "reject",
-        status_id: nextStatusId,
-        application_status_id: nextStatusId,
-        status: nextStatusId,
+        decision: DECISION_MAP[actionTarget.action] ||
+          (isApprove ? "approve" : "reject"),
       };
+      if (Number.isFinite(nextStatusId)) {
+        payload.status_id = nextStatusId;
+        payload.application_status_id = nextStatusId;
+      }
       const trimmed = actionComment.trim();
       if (trimmed) {
         payload.comment = trimmed;


### PR DESCRIPTION
## Summary
- update department head status labels to include the new forwarded state
- load only submissions that are pending department review (status 6)
- send explicit approve/reject transitions that forward approved requests to status 1 and rejections to status 8

## Testing
- npm run lint *(fails: Next.js prompts for ESLint configuration in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3c9b40f2c8322b9f809aa31f59a09