### PR TITLE
refactor: resolve summary template dynamically

### DIFF
--- a/frontend_project_fund/app/api/publication-summary/route.js
+++ b/frontend_project_fund/app/api/publication-summary/route.js
@@ -1,0 +1,184 @@
+import { NextResponse } from 'next/server';
+import { promises as fs } from 'fs';
+import path from 'path';
+import os from 'os';
+import { randomUUID } from 'crypto';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { patchDocument, PatchType, Paragraph, TextRun } from 'docx';
+
+export const runtime = 'nodejs';
+
+const execFileAsync = promisify(execFile);
+
+const templateCandidates = (() => {
+  const candidates = [];
+
+  if (process.env.PUBLICATION_TEMPLATE_PATH) {
+    candidates.push(process.env.PUBLICATION_TEMPLATE_PATH);
+  }
+
+  candidates.push(
+    path.join(process.cwd(), 'public', 'templates', 'publication_reward_template.docx'),
+    path.join(process.cwd(), '..', 'แบบฟอร์มสมัครรับ เงินรางวัลตีพิมพ์ - 2568.docx'),
+  );
+
+  return candidates;
+})();
+
+const resolveTemplatePath = async () => {
+  for (const candidate of templateCandidates) {
+    try {
+      await fs.access(candidate);
+      return candidate;
+    } catch {
+      // Try the next candidate
+    }
+  }
+
+  return null;
+};
+
+const createParagraph = (text = '') => new Paragraph({
+  children: [new TextRun({ text })],
+});
+
+const createParagraphPatch = (text = '') => ({
+  type: PatchType.PARAGRAPH,
+  children: [new TextRun({ text })],
+});
+
+const createDocumentPatch = (lines = []) => ({
+  type: PatchType.DOCUMENT,
+  children: (Array.isArray(lines) && lines.length > 0 ? lines : ['☑ ไม่พบรายการเอกสารแนบ'])
+    .map((line) => createParagraph(line)),
+});
+
+const buildPatches = (placeholders = {}, documentLines = []) => {
+  const patches = {};
+  Object.entries(placeholders).forEach(([key, value]) => {
+    if (key === 'document_line') {
+      return;
+    }
+    patches[key] = createParagraphPatch(value ?? '');
+  });
+
+  patches.document_line = createDocumentPatch(documentLines);
+  return patches;
+};
+
+const candidateLibreOfficePaths = () => {
+  if (process.platform === 'win32') {
+    return [
+      'C:/Program Files/LibreOffice/program/soffice.exe',
+      'C:/Program Files (x86)/LibreOffice/program/soffice.exe',
+      'soffice.exe',
+    ];
+  }
+
+  return ['soffice', 'libreoffice'];
+};
+
+const resolveLibreOffice = async () => {
+  const candidates = candidateLibreOfficePaths();
+  for (const candidate of candidates) {
+    try {
+      if (candidate.includes('/') || candidate.includes('\\') || candidate.includes(':')) {
+        await fs.access(candidate);
+        return candidate;
+      }
+      await execFileAsync('which', [candidate]);
+      return candidate;
+    } catch (error) {
+      // Try the next candidate
+    }
+  }
+  throw new Error('LibreOffice CLI (soffice) not found on server');
+};
+
+const convertDocxToPdf = async (docxBuffer) => {
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'pub-summary-'));
+  const docxPath = path.join(tmpDir, `summary-${randomUUID()}.docx`);
+  const pdfPath = path.join(tmpDir, `${path.parse(docxPath).name}.pdf`);
+
+  try {
+    await fs.writeFile(docxPath, docxBuffer);
+
+    let libreOffice;
+    try {
+      libreOffice = await resolveLibreOffice();
+    } catch (error) {
+      const enhancedError = new Error('LIBREOFFICE_NOT_INSTALLED');
+      enhancedError.cause = error;
+      throw enhancedError;
+    }
+
+    await execFileAsync(libreOffice, ['--headless', '--convert-to', 'pdf', '--outdir', tmpDir, docxPath], {
+      timeout: 30000,
+    });
+
+    const pdfBuffer = await fs.readFile(pdfPath);
+    return pdfBuffer;
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  }
+};
+
+export async function POST(request) {
+  try {
+    const payload = await request.json();
+    const { placeholders, documentLines } = payload || {};
+
+    if (!placeholders || typeof placeholders !== 'object') {
+      return NextResponse.json({ error: 'INVALID_PAYLOAD', details: 'placeholders object is required' }, { status: 400 });
+    }
+
+    const templatePath = await resolveTemplatePath();
+
+    if (!templatePath) {
+      return NextResponse.json({ error: 'TEMPLATE_NOT_AVAILABLE' }, { status: 503 });
+    }
+
+    const templateBuffer = await fs.readFile(templatePath);
+    const patches = buildPatches(placeholders, documentLines);
+
+    const patchedDocx = await patchDocument({
+      outputType: 'nodebuffer',
+      data: templateBuffer,
+      patches,
+      keepOriginalStyles: true,
+    });
+
+    try {
+      const pdfBuffer = await convertDocxToPdf(patchedDocx);
+      return new NextResponse(pdfBuffer, {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/pdf',
+          'Content-Disposition': 'inline; filename="publication-summary.pdf"',
+        },
+      });
+    } catch (conversionError) {
+      console.error('DOCX to PDF conversion failed:', conversionError);
+
+      if (conversionError?.message === 'LIBREOFFICE_NOT_INSTALLED') {
+        return NextResponse.json(
+          {
+            error: 'LIBREOFFICE_NOT_INSTALLED',
+            details:
+              'LibreOffice (soffice) is required on the server to convert the official DOCX template to PDF. Install LibreOffice and redeploy the service to enable exact template rendering.',
+          },
+          { status: 503 },
+        );
+      }
+
+      return NextResponse.json(
+        { error: 'DOCX_TO_PDF_FAILED', details: conversionError.message },
+        { status: 500 },
+      );
+    }
+  } catch (error) {
+    console.error('Failed to generate publication summary document:', error);
+    return NextResponse.json({ error: 'SUMMARY_GENERATION_FAILED', details: error.message }, { status: 500 });
+  }
+}

--- a/frontend_project_fund/app/globals.css
+++ b/frontend_project_fund/app/globals.css
@@ -1,5 +1,5 @@
 @import "tailwindcss";
-@import url('https://fonts.googleapis.com/css2?family=Anuphan:wght@100..700&family=Raleway:ital,wght@0,100..900;1,100..900&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Anuphan:wght@100..700&family=Raleway:ital,wght@0,100..900;1,100..900&family=TH+Sarabun+New:wght@400;700&display=swap');
 :root {
   --background: #ffffff;
   --foreground: #171717;

--- a/frontend_project_fund/app/lib/publication_summary.js
+++ b/frontend_project_fund/app/lib/publication_summary.js
@@ -1,0 +1,333 @@
+const THAI_MONTHS = [
+  'มกราคม',
+  'กุมภาพันธ์',
+  'มีนาคม',
+  'เมษายน',
+  'พฤษภาคม',
+  'มิถุนายน',
+  'กรกฎาคม',
+  'สิงหาคม',
+  'กันยายน',
+  'ตุลาคม',
+  'พฤศจิกายน',
+  'ธันวาคม',
+];
+
+const THAI_DIGITS = ['ศูนย์', 'หนึ่ง', 'สอง', 'สาม', 'สี่', 'ห้า', 'หก', 'เจ็ด', 'แปด', 'เก้า'];
+
+const THAI_UNITS = ['', 'สิบ', 'ร้อย', 'พัน', 'หมื่น', 'แสน'];
+
+const AUTHOR_ROLE_TEXT = {
+  first_author: 'เป็นผู้ประพันธ์ชื่อแรก (first author)',
+  corresponding_author: 'เป็นผู้ประพันธ์บรรณกิจ (corresponding author)',
+  coauthor: 'เป็นผู้ร่วมประพันธ์ (co-author)',
+};
+
+const QUARTILE_TEXT = {
+  T5: 'บทความตีพิมพ์ในวารสารระดับนานาชาติ ควอไทล์ 1 (ลำดับ 5% แรก) ที่สามารถสืบค้นได้ในฐานข้อมูล WOS หรือ ISI หรือ SCOPUS',
+  T10: 'บทความตีพิมพ์ในวารสารระดับนานาชาติ ควอไทล์ 1 (ลำดับ 10% แรก) ที่สามารถสืบค้นได้ในฐานข้อมูล WOS หรือ ISI หรือ SCOPUS',
+  Q1: 'บทความตีพิมพ์ในวารสารระดับนานาชาติ ควอไทล์ 1 ที่สามารถสืบค้นได้ในฐานข้อมูล WOS หรือ ISI หรือ SCOPUS',
+  Q2: 'บทความตีพิมพ์ในวารสารระดับนานาชาติ ควอไทล์ 2 ที่สามารถสืบค้นได้ในฐานข้อมูล WOS หรือ ISI หรือ SCOPUS',
+  Q3: 'บทความตีพิมพ์ในวารสารระดับนานาชาติ ควอไทล์ 3 ที่สามารถสืบค้นได้ในฐานข้อมูล WOS หรือ ISI หรือ SCOPUS',
+  Q4: 'บทความตีพิมพ์ในวารสารระดับนานาชาติ ควอไทล์ 4 ที่สามารถสืบค้นได้ในฐานข้อมูล WOS หรือ ISI หรือ SCOPUS',
+  TCI: 'บทความตีพิมพ์ในวารสารระดับนานาชาติ อยู่ในฐานข้อมูล WOS หรือ ISI หรือ SCOPUS หรือวารสารที่อยู่ในฐานข้อมูล TCI',
+};
+
+const MONTH_NAMES_SHORT = {
+  '01': 'มกราคม',
+  '02': 'กุมภาพันธ์',
+  '03': 'มีนาคม',
+  '04': 'เมษายน',
+  '05': 'พฤษภาคม',
+  '06': 'มิถุนายน',
+  '07': 'กรกฎาคม',
+  '08': 'สิงหาคม',
+  '09': 'กันยายน',
+  '10': 'ตุลาคม',
+  '11': 'พฤศจิกายน',
+  '12': 'ธันวาคม',
+};
+
+const safeDisplay = (value, fallback = '—') => {
+  if (value === null || value === undefined) {
+    return fallback;
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : fallback;
+  }
+
+  if (typeof value === 'number' && Number.isNaN(value)) {
+    return fallback;
+  }
+
+  return value;
+};
+
+const readThaiNumber = (value) => {
+  const sanitized = `${value}`.replace(/[^0-9]/g, '');
+  if (!sanitized) {
+    return '';
+  }
+
+  if (sanitized.length > 6) {
+    const head = sanitized.slice(0, -6);
+    const tail = sanitized.slice(-6);
+    const headText = readThaiNumber(head);
+    const tailText = readThaiNumber(tail);
+    return `${headText}ล้าน${tailText || ''}`;
+  }
+
+  const digits = sanitized.split('').map((ch) => parseInt(ch, 10));
+  const len = digits.length;
+  let result = '';
+
+  digits.forEach((digit, index) => {
+    if (Number.isNaN(digit) || digit === 0) {
+      return;
+    }
+
+    const position = len - index - 1;
+    if (position === 0) {
+      if (digit === 1 && len > 1) {
+        result += 'เอ็ด';
+      } else {
+        result += THAI_DIGITS[digit];
+      }
+      return;
+    }
+
+    if (position === 1) {
+      if (digit === 2) {
+        result += 'ยี่สิบ';
+        return;
+      }
+      if (digit === 1) {
+        result += 'สิบ';
+        return;
+      }
+    }
+
+    result += `${THAI_DIGITS[digit]}${THAI_UNITS[position]}`;
+  });
+
+  return result;
+};
+
+const toBahtText = (amount) => {
+  if (amount === null || amount === undefined || amount === '') {
+    return '';
+  }
+
+  const numeric = parseFloat(`${amount}`.toString().replace(/,/g, ''));
+  if (Number.isNaN(numeric)) {
+    return '';
+  }
+
+  if (numeric === 0) {
+    return 'ศูนย์บาทถ้วน';
+  }
+
+  const fixed = Math.abs(numeric).toFixed(2);
+  const [bahtPart, satangPart] = fixed.split('.');
+  const bahtText = readThaiNumber(bahtPart) || 'ศูนย์';
+  const satangValue = parseInt(satangPart, 10);
+
+  let result = `${bahtText}บาท`;
+  if (satangValue === 0) {
+    result += 'ถ้วน';
+  } else {
+    result += `${readThaiNumber(satangPart)}สตางค์`;
+  }
+
+  return result;
+};
+
+const formatThaiDate = (value) => {
+  if (!value) {
+    return '—';
+  }
+
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return '—';
+  }
+
+  const day = date.getDate();
+  const month = THAI_MONTHS[date.getMonth()] ?? '';
+  const year = date.getFullYear() + 543;
+  return `${day} ${month} ${year}`;
+};
+
+const formatThaiMonthYear = (value) => {
+  if (!value) {
+    return '';
+  }
+
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+
+  const month = (`0${date.getMonth() + 1}`).slice(-2);
+  const year = date.getFullYear() + 543;
+  const monthName = MONTH_NAMES_SHORT[month] ?? '';
+  if (!monthName) {
+    return `${year}`;
+  }
+  return `${monthName} ${year}`;
+};
+
+const getPublicationYear = (value) => {
+  if (!value) {
+    return '';
+  }
+
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    const numericYear = parseInt(`${value}`, 10);
+    if (!Number.isNaN(numericYear)) {
+      return `${numericYear + 543}`;
+    }
+    return '';
+  }
+
+  return `${date.getFullYear() + 543}`;
+};
+
+const mapAuthorRole = (authorType) => AUTHOR_ROLE_TEXT[authorType] ?? '';
+
+const mapQuartileLine = (quartile) => QUARTILE_TEXT[quartile] ?? '';
+
+const formatCurrency = (value) => {
+  const numeric = parseFloat(`${value}`.toString().replace(/,/g, ''));
+  if (Number.isNaN(numeric)) {
+    return '';
+  }
+
+  return numeric.toLocaleString('th-TH', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+};
+
+const buildDocumentLines = (documents = []) => {
+  if (!Array.isArray(documents) || documents.length === 0) {
+    return ['☑ ไม่พบรายการเอกสารแนบ'];
+  }
+
+  return documents.map((doc) => {
+    const label = safeDisplay(doc.type || doc.name, 'เอกสารแนบ');
+    return `☑ ${label} — จำนวน 1 ฉบับ`;
+  });
+};
+
+export const buildPublicationSummaryContext = ({
+  formData = {},
+  currentUser = {},
+  documents = [],
+  systemConfig = {},
+  fiscalYear = null,
+}) => {
+  const dateThai = formatThaiDate(new Date());
+  const employmentDate = formatThaiDate(currentUser?.date_of_employment);
+
+  const applicantNameFromUser = [
+    safeDisplay(currentUser?.user_fname, ''),
+    safeDisplay(currentUser?.user_lname, ''),
+  ].filter(Boolean).join(' ').trim();
+
+  const applicantName = safeDisplay(formData?.applicant_name, applicantNameFromUser || '—');
+  const positionName = safeDisplay(currentUser?.position_name, '—');
+  const installmentDisplay = safeDisplay(systemConfig?.installment, '—');
+  const fiscalYearDisplay = fiscalYear ? safeDisplay(fiscalYear, '—') : '—';
+
+  const totalAmountNumeric = parseFloat(`${formData?.total_amount ?? 0}`.toString().replace(/,/g, '')) || 0;
+  const totalAmountDisplay = formatCurrency(totalAmountNumeric);
+  const totalAmountText = toBahtText(totalAmountNumeric);
+
+  const authorNameList = safeDisplay(formData?.author_name_list, '');
+  const paperTitle = safeDisplay(formData?.article_title, '');
+  const journalName = safeDisplay(formData?.journal_name, '');
+  const publicationDate = safeDisplay(formatThaiDate(formData?.publication_date), '—');
+  const publicationYear = getPublicationYear(formData?.publication_date);
+  const volumeIssue = safeDisplay(formData?.journal_issue, '');
+  const pageNumbers = safeDisplay(formData?.journal_pages, '');
+
+  const authorRoleSentence = mapAuthorRole(formData?.author_status);
+  const quartileSentence = mapQuartileLine(formData?.journal_quartile);
+  const signatureText = safeDisplay(formData?.signature, '........................................');
+  const kkuReportYear = safeDisplay(systemConfig?.kku_report_year, '—');
+
+  const documentLines = buildDocumentLines(documents);
+  const documentListText = documentLines.join('\n');
+
+  const articleDetailText = [
+    authorNameList,
+    paperTitle,
+    journalName,
+    publicationYear || publicationDate,
+    volumeIssue,
+    pageNumbers,
+  ].filter((part) => part && `${part}`.trim() !== '').join(' ');
+
+  const placeholders = {
+    date_th: dateThai,
+    applicant_name: applicantName,
+    date_of_employment: employmentDate,
+    position: positionName,
+    installment: installmentDisplay,
+    total_amount: totalAmountDisplay,
+    total_amount_text: totalAmountText,
+    author_name_list: authorNameList,
+    paper_title: paperTitle,
+    journal_name: journalName,
+    publication_date: publicationDate,
+    publication_year: publicationYear,
+    volume_issue: volumeIssue,
+    page_numbers: pageNumbers,
+    page_number: pageNumbers,
+    author_role: authorRoleSentence,
+    quartile_line: quartileSentence,
+    document_line: documentListText,
+    kku_report_year: kkuReportYear,
+    signature: signatureText,
+  };
+
+  return {
+    placeholders,
+    documentLines,
+    meta: {
+      dateThai,
+      employmentDate,
+      applicantName,
+      positionName,
+      installmentDisplay,
+      fiscalYearDisplay,
+      totalAmountDisplay,
+      totalAmountText,
+      authorNameList,
+      paperTitle,
+      journalName,
+      publicationDate,
+      publicationYear,
+      volumeIssue,
+      pageNumbers,
+      authorRoleSentence,
+      quartileSentence,
+      documentListText,
+      signatureText,
+      kkuReportYear,
+      articleDetailText,
+    },
+  };
+};
+
+export const publicationSummaryHelpers = {
+  formatThaiDate,
+  toBahtText,
+  safeDisplay,
+};
+
+export default buildPublicationSummaryContext;

--- a/frontend_project_fund/app/lib/system_config_api.js
+++ b/frontend_project_fund/app/lib/system_config_api.js
@@ -83,6 +83,10 @@ export const systemConfigAPI = {
       activity_support_announcement: root?.activity_support_announcement ?? null,
       conference_announcement: root?.conference_announcement ?? null,
       service_announcement: root?.service_announcement ?? null,
+
+      // additional fields used in member forms
+      kku_report_year: root?.kku_report_year ?? null,
+      installment: root?.installment ?? null,
     };
   },
 };

--- a/frontend_project_fund/app/member/components/applications/PublicationRewardForm.js
+++ b/frontend_project_fund/app/member/components/applications/PublicationRewardForm.js
@@ -21,6 +21,7 @@ import Swal from 'sweetalert2';
 import { PDFDocument } from 'pdf-lib';
 import { notificationsAPI } from '../../../lib/notifications_api';
 import { systemConfigAPI } from '../../../lib/system_config_api';
+import buildPublicationSummaryContext from '../../../lib/publication_summary';
 import { getAuthorSubmissionFields } from './PublicationRewardForm.helpers.mjs';
 
 // =================================================================
@@ -89,6 +90,47 @@ const formatBankAccount = (value) => {
   const cleaned = value.replace(/\D/g, '');
   // Limit to 15 digits
   return cleaned.slice(0, 15);
+};
+
+// Ensure summary generator fonts are loaded before drawing to canvas
+const SUMMARY_FONT_DESCRIPTORS = [
+  '400 30px "TH Sarabun New"',
+  '700 30px "TH Sarabun New"',
+  '400 34px "TH Sarabun New"',
+  '700 34px "TH Sarabun New"',
+  '700 36px "TH Sarabun New"',
+];
+
+let summaryFontsLoaded = false;
+
+const ensureSummaryFontsLoaded = async () => {
+  if (summaryFontsLoaded) {
+    return;
+  }
+
+  if (typeof document === 'undefined' || !document.fonts?.load) {
+    summaryFontsLoaded = true;
+    return;
+  }
+
+  try {
+    const loaders = SUMMARY_FONT_DESCRIPTORS.map(async (descriptor) => {
+      try {
+        if (!document.fonts.check(descriptor)) {
+          await document.fonts.load(descriptor);
+        }
+      } catch (err) {
+        console.warn('Unable to load font descriptor', descriptor, err);
+      }
+    });
+
+    await Promise.all(loaders);
+    await document.fonts.ready;
+    summaryFontsLoaded = true;
+  } catch (error) {
+    console.warn('Unable to ensure summary fonts are ready:', error);
+    summaryFontsLoaded = true; // avoid retry loops; canvas will fallback gracefully
+  }
 };
 
 // Quartile sorting order
@@ -256,6 +298,412 @@ const mergePDFs = async (pdfFiles) => {
   const mergedBytes = await merged.save();
   const blob = new Blob([mergedBytes], { type: 'application/pdf' });
   return { blob, skipped }; // << คืน Blob + รายชื่อไฟล์ที่ถูกข้าม
+};
+
+
+// =================================================================
+// AUTO-GENERATED SUMMARY PDF
+// =================================================================
+
+const wrapParagraph = (ctx, text, font, maxWidth) => {
+  ctx.font = font;
+  if (maxWidth <= 0) return [text];
+
+  const content = `${text}`;
+  if (!content) return [''];
+
+  const words = content.split(' ');
+  const useCharWrap = words.length === 1;
+  const lines = [];
+
+  if (useCharWrap) {
+    let current = '';
+    for (const char of content) {
+      const test = current + char;
+      if (ctx.measureText(test).width > maxWidth && current) {
+        lines.push(current);
+        current = char;
+      } else {
+        current = test;
+      }
+    }
+    if (current) lines.push(current);
+    return lines;
+  }
+
+  let current = '';
+  words.forEach((rawWord) => {
+    const word = rawWord.trim();
+    if (!word) return;
+    const test = current ? `${current} ${word}` : word;
+    if (ctx.measureText(test).width > maxWidth && current) {
+      lines.push(current);
+      current = word;
+    } else {
+      current = test;
+    }
+  });
+
+  if (current) lines.push(current);
+  return lines.length > 0 ? lines : [''];
+};
+
+const wrapEntryLines = (ctx, entry, style, contentWidth, bulletIndent) => {
+  const paragraphs = `${entry.text ?? ''}`.split('\n');
+  const lines = [];
+  const indentValue = entry.indent ?? style.indent ?? 0;
+  const indentWidth = (style.bullet ? bulletIndent : 0) + indentValue;
+  const prefixExtra = entry.prefix ? 40 : 0;
+  const maxWidth = Math.max(contentWidth - indentWidth - prefixExtra, 50);
+
+  paragraphs.forEach((paragraph, index) => {
+    const text = paragraph.trim();
+    if (index > 0) {
+      lines.push({ text: '', isSpacer: true, indent: indentValue });
+    }
+
+    if (!text) {
+      lines.push({ text: '', indent: indentValue });
+      return;
+    }
+
+    const wrapped = wrapParagraph(ctx, text, style.font, maxWidth);
+    wrapped.forEach((segment, segmentIndex) => {
+      lines.push({
+        text: segment,
+        isBullet: style.bullet && segmentIndex === 0 && !entry.prefix,
+        isBulletContinuation: style.bullet && segmentIndex > 0,
+        prefix: segmentIndex === 0 ? (entry.prefix || null) : null,
+        indent: indentValue,
+      });
+    });
+  });
+
+  return lines;
+};
+
+const generateSummaryPdfViaCanvas = async (summaryContext) => {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return null;
+  }
+
+  const { meta } = summaryContext;
+
+  try {
+    await ensureSummaryFontsLoaded();
+
+    const canvas = document.createElement('canvas');
+    const width = 1240;
+    const marginX = 120;
+    const marginY = 100;
+    const bulletIndent = 56;
+    const contentWidth = width - marginX * 2;
+
+    canvas.width = width;
+    canvas.height = 2200;
+
+    const ctx = canvas.getContext('2d');
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    ctx.textBaseline = 'top';
+
+    const fontFamily = '"TH Sarabun New", "Sarabun", "Tahoma", sans-serif';
+    const baseStyle = {
+      font: `30px ${fontFamily}`,
+      lineHeight: 42,
+      color: '#111827',
+      align: 'left',
+      spacingAfter: 12,
+    };
+
+    const styles = {
+      text: baseStyle,
+      title: {
+        ...baseStyle,
+        font: `bold 36px ${fontFamily}`,
+        lineHeight: 50,
+        color: '#1f2937',
+        align: 'center',
+        spacingAfter: 6,
+      },
+      subtitle: {
+        ...baseStyle,
+        font: `bold 34px ${fontFamily}`,
+        lineHeight: 46,
+        color: '#1f2937',
+        align: 'center',
+        spacingAfter: 24,
+      },
+      location: {
+        ...baseStyle,
+        spacingAfter: 6,
+      },
+      date: {
+        ...baseStyle,
+        align: 'right',
+        spacingAfter: 18,
+      },
+      subject: {
+        ...baseStyle,
+        spacingAfter: 10,
+      },
+      salutation: {
+        ...baseStyle,
+        spacingAfter: 14,
+      },
+      body: {
+        ...baseStyle,
+        spacingAfter: 14,
+      },
+      bodyNoIndent: {
+        ...baseStyle,
+        spacingAfter: 12,
+      },
+      list: {
+        ...baseStyle,
+        spacingAfter: 12,
+        indent: 36,
+      },
+      documentList: {
+        ...baseStyle,
+        spacingAfter: 16,
+        indent: 36,
+      },
+      condition: {
+        ...baseStyle,
+        spacingAfter: 10,
+        indent: 36,
+      },
+      signoff: {
+        ...baseStyle,
+        align: 'right',
+        spacingBefore: 24,
+        spacingAfter: 10,
+      },
+      signature: {
+        ...baseStyle,
+        align: 'right',
+        spacingAfter: 6,
+      },
+      signatureName: {
+        ...baseStyle,
+        align: 'right',
+        spacingAfter: 0,
+      },
+    };
+
+    const installmentDisplay = meta.installmentDisplay || '—';
+    const totalAmountFormatted = meta.totalAmountDisplay || '0.00';
+    const totalAmountText = meta.totalAmountText || '—';
+    const articleDetailText = meta.articleDetailText || '—';
+    const authorRoleSentence = meta.authorRoleSentence || '—';
+    const quartileSentence = meta.quartileSentence || '';
+    const documentListText = meta.documentListText || '☑ ไม่พบรายการเอกสารแนบ';
+    const signatureText = meta.signatureText || '........................................';
+    const kkuReportYear = meta.kkuReportYear || '—';
+
+    const content = [
+      { type: 'title', text: 'ใบสมัครเพื่อขอใช้เงินกองทุนวิจัย นวัตกรรม และบริการวิชาการ วิทยาลัยการคอมพิวเตอร์ มหาวิทยาลัยขอนแก่น' },
+      { type: 'subtitle', text: 'เงินรางวัลการตีพิมพ์เผยแพร่ผลงานวิจัยที่ได้รับการตีพิมพ์ในสาขาวิทยาศาสตร์และเทคโนโลยี' },
+      { type: 'location', text: 'เขียนที่  วิทยาลัยการคอมพิวเตอร์ มหาวิทยาลัยขอนแก่น' },
+      { type: 'date', text: meta.dateThai || '—' },
+      { type: 'subject', text: 'เรื่องขออนุมัติเบิกค่าใช้จ่ายในการสนับสนุนการตีพิมพ์ผลงานวิจัยในสาขาวิทยาศาสตร์และเทคโนโลยี' },
+      { type: 'salutation', text: 'เรียน  คณบดีวิทยาลัยการคอมพิวเตอร์' },
+      {
+        type: 'body',
+        text: `ข้าพเจ้า ${meta.applicantName || '—'} บรรจุเมื่อวันที่ ${meta.employmentDate || '—'}          ตำแหน่ง ${meta.positionName || '—'} สังกัดหน่วยงาน/สาขาวิชา วิทยาลัยการคอมพิวเตอร์ มหาวิทยาลัยขอนแก่น ขอยื่นใบสมัครเพื่อขอใช้เงินกองทุนวิจัย นวัตกรรมและบริการวิชาการ วิทยาลัยการคอมพิวเตอร์ มหาวิทยาลัยขอนแก่น ประจำปีงบประมาณ พ.ศ. ${meta.fiscalYearDisplay || '—'}  งวดที่ ${installmentDisplay} ดังนี้`,
+      },
+      {
+        type: 'body',
+        text: `ข้าพเจ้าขออนุมัติใช้เงินกองทุนฯ ในวงเงินจำนวน ${totalAmountFormatted} บาท (${totalAmountText}) เพื่อเป็นค่าตอบแทนผลงานวิจัยที่ได้รับการตีพิมพ์ในวารสาร ดังนี้`,
+      },
+      { type: 'list', text: '1) ผู้แต่ง. ชื่อเรื่อง. ชื่อวารสาร. ปีที่พิมพ์. ปีที่ (ฉบับที่) หน้า.' },
+      { type: 'list', text: articleDetailText },
+      {
+        type: 'body',
+        text: `ข้าพเจ้า ${authorRoleSentence} ได้ตีพิมพ์ ${quartileSentence}`.trim(),
+      },
+      { type: 'body', text: 'ทั้งนี้ได้แนบ หลักฐานเพื่อประกอบการพิจารณา ดังนี้' },
+      { type: 'documentList', text: documentListText },
+      { type: 'bodyNoIndent', text: 'ข้าพเจ้าขอรับรองว่า' },
+      {
+        type: 'condition',
+        text: 'ผลงานตีพิมพ์ที่ขอรับการสนับสนุนไม่เคยได้รับการจัดสรรทุนของมหาวิทยาลัย และทุนส่งเสริมการวิจัยจากกองทุนวิจัย นวัตกรรม และบริการวิชาการ วิทยาลัยการคอมพิวเตอร์',
+      },
+      {
+        type: 'condition',
+        text: `จะปฏิบัติตามระเบียบมหาวิทยาลัยขอนแก่น ว่าด้วยกองทุนวิจัยในระดับคณะ พ.ศ. ${kkuReportYear} รวมถึงหลักเกณฑ์และประกาศอื่นใดที่เกี่ยวข้องทุกประการ`,
+      },
+      { type: 'signoff', text: 'ขอแสดงความนับถือ' },
+      { type: 'signature', text: `(ลงชื่อ) ${signatureText} ผู้สมัครขอใช้เงิน` },
+      { type: 'signatureName', text: `(${meta.applicantName || '—'})` },
+    ];
+
+    const processed = [];
+    let totalHeight = marginY;
+
+    content.forEach((entry) => {
+      const style = styles[entry.type] || styles.text;
+      const lines = wrapEntryLines(ctx, entry, style, contentWidth, bulletIndent);
+      const visibleLines = lines.length > 0 ? lines : [{ text: '' }];
+      const spacingBefore = style.spacingBefore || 0;
+      const spacingAfter = style.spacingAfter || 0;
+      const entryHeight = spacingBefore + (visibleLines.length * style.lineHeight) + spacingAfter;
+      totalHeight += entryHeight;
+      processed.push({ ...entry, style, lines: visibleLines });
+    });
+
+    totalHeight += marginY;
+
+    canvas.height = totalHeight;
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    ctx.textBaseline = 'top';
+
+    let cursorY = marginY;
+
+    processed.forEach((entry) => {
+      const { style, lines } = entry;
+      if (style.spacingBefore) {
+        cursorY += style.spacingBefore;
+      }
+
+      ctx.font = style.font;
+      ctx.fillStyle = style.color || '#111827';
+
+      const alignment = style.align || 'left';
+      if (alignment === 'center') {
+        ctx.textAlign = 'center';
+        lines.forEach((line) => {
+          const text = typeof line === 'string' ? line : line.text || '';
+          ctx.fillText(text, width / 2, cursorY);
+          cursorY += style.lineHeight;
+        });
+      } else if (alignment === 'right') {
+        ctx.textAlign = 'right';
+        const rightX = marginX + contentWidth;
+        lines.forEach((line) => {
+          const text = typeof line === 'string' ? line : line.text || '';
+          ctx.fillText(text, rightX, cursorY);
+          cursorY += style.lineHeight;
+        });
+      } else {
+        ctx.textAlign = 'left';
+        lines.forEach((line) => {
+          const text = typeof line === 'string' ? line : line.text || '';
+          const indent = line.indent ?? entry.indent ?? style.indent ?? 0;
+          const drawX = marginX + indent;
+          if (line.prefix) {
+            ctx.fillText(`${line.prefix} ${text}`, drawX, cursorY);
+          } else if (line.isBullet) {
+            ctx.fillText(`• ${text}`, drawX, cursorY);
+          } else if (line.isBulletContinuation) {
+            ctx.fillText(text, drawX + bulletIndent, cursorY);
+          } else {
+            ctx.fillText(text, drawX, cursorY);
+          }
+          cursorY += style.lineHeight;
+        });
+      }
+
+      if (style.spacingAfter) {
+        cursorY += style.spacingAfter;
+      }
+    });
+
+    const dataUrl = canvas.toDataURL('image/png');
+    const pngBytes = await fetch(dataUrl).then(res => res.arrayBuffer());
+    const pdfDoc = await PDFDocument.create();
+    const pngImage = await pdfDoc.embedPng(pngBytes);
+    const pngDims = pngImage.scale(1);
+    const pageWidth = 595.28; // A4 width in points
+    const pageHeight = (pngDims.height / pngDims.width) * pageWidth;
+    const page = pdfDoc.addPage([pageWidth, pageHeight]);
+
+    page.drawImage(pngImage, {
+      x: 0,
+      y: 0,
+      width: pageWidth,
+      height: pageHeight,
+    });
+
+    const pdfBytes = await pdfDoc.save();
+    return new Blob([pdfBytes], { type: 'application/pdf' });
+  } catch (error) {
+    console.error('Failed to generate summary PDF via canvas:', error);
+    return null;
+  }
+};
+
+const generateSubmissionSummaryPdf = async ({
+  formData,
+  currentUser,
+  documents,
+  systemConfig,
+  fiscalYear,
+}) => {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return null;
+  }
+
+  const filteredDocuments = Array.isArray(documents)
+    ? documents.filter(doc => !doc.isGenerated)
+    : [];
+
+  const summaryContext = buildPublicationSummaryContext({
+    formData,
+    currentUser,
+    documents: filteredDocuments,
+    systemConfig,
+    fiscalYear,
+  });
+
+  try {
+    const response = await fetch('/api/publication-summary', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        placeholders: summaryContext.placeholders,
+        documentLines: summaryContext.documentLines,
+      }),
+    });
+
+    if (response.ok) {
+      const buffer = await response.arrayBuffer();
+      return new Blob([buffer], { type: 'application/pdf' });
+    }
+
+    let errorPayload = null;
+    try {
+      errorPayload = await response.json();
+    } catch (readError) {
+      console.warn('Unable to parse publication summary error payload:', readError);
+      errorPayload = { details: await response.text() };
+    }
+
+    const errorCode = errorPayload?.error;
+    const errorDetails = errorPayload?.details;
+
+    if (errorCode === 'LIBREOFFICE_NOT_INSTALLED') {
+      Toast.fire({
+        icon: 'warning',
+        title: 'ไม่สามารถสร้างแบบฟอร์มจากไฟล์ Word ได้',
+        text: 'กรุณาติดตั้ง LibreOffice (คำสั่ง soffice) บนเซิร์ฟเวอร์ แล้วลองใหม่อีกครั้ง เพื่อใช้งานแบบฟอร์มเวอร์ชันเดียวกับ DOCX',
+      });
+    } else {
+      Toast.fire({
+        icon: 'warning',
+        title: 'ไม่สามารถสร้างแบบฟอร์มเวอร์ชัน Word ได้',
+        text: errorDetails || 'ระบบจะใช้รูปแบบ PDF เดิมแทนชั่วคราว',
+      });
+    }
+
+    console.warn('Docx-based summary generation failed:', errorPayload);
+  } catch (error) {
+    console.warn('Unable to generate docx-based summary PDF:', error);
+  }
+
+  return generateSummaryPdfViaCanvas(summaryContext);
 };
 
 
@@ -546,6 +994,10 @@ export default function PublicationRewardForm({ onNavigate, categoryId, yearId, 
   const [years, setYears] = useState([]);
   const [currentSubmissionId, setCurrentSubmissionId] = useState(null);
   const [currentUser, setCurrentUser] = useState(null);
+  const [systemConfigInfo, setSystemConfigInfo] = useState({
+    installment: null,
+    kku_report_year: null,
+  });
   const [mergedPdfFile, setMergedPdfFile] = useState(null);
   const [availableAuthorStatuses, setAvailableAuthorStatuses] = useState([]);
   const [availableQuartiles, setAvailableQuartiles] = useState([]);
@@ -1104,6 +1556,11 @@ export default function PublicationRewardForm({ onNavigate, categoryId, yearId, 
         const rawWindow = await systemConfigAPI.getWindow();
         const root = rawWindow?.data ?? rawWindow; // รองรับทั้ง 2 รูปแบบ (admin vs window)
 
+        setSystemConfigInfo({
+          installment: root?.installment ?? null,
+          kku_report_year: root?.kku_report_year ?? null,
+        });
+
         // อ่าน announcement_id ที่ถูกต้องจาก system_config
         setAnnouncementLock({
           main_annoucement: root?.config_id ?? null,
@@ -1118,6 +1575,7 @@ export default function PublicationRewardForm({ onNavigate, categoryId, yearId, 
       } catch (e) {
         console.warn('Cannot fetch system-config window; main_annoucement/reward_announcement will be null', e);
         setAnnouncementLock({ main_annoucement: null, reward_announcement: null });
+        setSystemConfigInfo({ installment: null, kku_report_year: null });
       }
 
       console.log('Raw API responses:');
@@ -1919,69 +2377,123 @@ const showSubmissionConfirmation = async () => {
     });
   }
 
-    // Check if files exist
-    if (allFiles.length === 0) {
-      Swal.fire({
-        icon: 'warning',
-        title: 'ไม่พบเอกสารแนบ',
-        text: 'กรุณาแนบไฟล์บทความอย่างน้อย 1 ไฟล์',
-        confirmButtonColor: '#3085d6'
-      });
-      return false;
+  // Check if files exist
+  if (allFiles.length === 0) {
+    Swal.fire({
+      icon: 'warning',
+      title: 'ไม่พบเอกสารแนบ',
+      text: 'กรุณาแนบไฟล์บทความอย่างน้อย 1 ไฟล์',
+      confirmButtonColor: '#3085d6'
+    });
+    return false;
+  }
+
+  let summaryFile = null;
+  try {
+    const selectedYear = years.find(year => year.year_id === formData.year_id);
+    const summaryBlob = await generateSubmissionSummaryPdf({
+      formData,
+      currentUser,
+      documents: allFilesList,
+      systemConfig: systemConfigInfo,
+      fiscalYear: selectedYear?.year || null,
+    });
+
+    if (summaryBlob) {
+      summaryFile = new File([summaryBlob], '00_แบบฟอร์มสรุปคำขอ.pdf', { type: 'application/pdf' });
     }
+  } catch (error) {
+    console.error('Failed to generate auto-summary PDF:', error);
+  }
 
-    // Create merged PDF
-    let mergedPdfBlob = null;
-    let mergedPdfUrl = null;
-    let previewViewed = false;
+  const filesForDisplay = summaryFile
+    ? [
+        {
+          name: summaryFile.name,
+          type: 'เอกสารที่ระบบจัดทำจากแบบฟอร์ม',
+          size: summaryFile.size,
+          isGenerated: true,
+        },
+        ...allFilesList,
+      ]
+    : [...allFilesList];
 
-    try {
-      // Show loading while merging PDF
-      Swal.fire({
-        title: 'กำลังเตรียมเอกสาร...',
-        html: 'กำลังรวมไฟล์ PDF ทั้งหมด',
-        allowOutsideClick: false,
-        showConfirmButton: false,
-        willOpen: () => {
-          Swal.showLoading();
-        }
-      });
+  const fileListHtml = filesForDisplay.length
+    ? filesForDisplay
+        .map(file => {
+          const sizeValue = typeof file.size === 'number' && !Number.isNaN(file.size)
+            ? `${(file.size / 1024 / 1024).toFixed(2)} MB`
+            : '';
+          const icon = file.isGenerated ? '⭐' : '📄';
+          const typeLabel = file.type ? `<span class="ml-2 text-[10px] text-gray-500">(${file.type})</span>` : '';
+          const sizeLabel = sizeValue
+            ? `<span class="text-gray-500 ml-2 whitespace-nowrap">${sizeValue}</span>`
+            : '<span class="ml-2 whitespace-nowrap text-gray-300">&nbsp;</span>';
+          return `
+            <li class="flex justify-between items-start text-xs">
+              <span>${icon} ${file.name}${typeLabel}</span>
+              ${sizeLabel}
+            </li>
+          `;
+        })
+        .join('')
+    : '<li class="text-xs text-gray-500">ไม่พบไฟล์ที่เลือก</li>';
 
-      // Filter PDF files only
-      const pdfFiles = allFiles.filter(file => file.type === 'application/pdf');
-      
-      if (pdfFiles.length > 0) {
-        if (pdfFiles.length > 1) {
-          // Merge multiple PDFs (robust)
-          const { blob, skipped } = await mergePDFs(pdfFiles);
-          const mergedFile = new File([blob], 'merged_documents.pdf', { type: 'application/pdf' });
-          setMergedPdfFile(mergedFile);
-          mergedPdfUrl = URL.createObjectURL(blob);
-          if (skipped?.length) {
-            Toast.fire({ icon: 'warning', title: 'ข้ามไฟล์ PDF บางไฟล์', text: skipped.join(', ') });
-          }
-        } else {
-          // Use single PDF
-          const one = pdfFiles[0];
-          setMergedPdfFile(one);
-          mergedPdfUrl = URL.createObjectURL(one);
-        }
+  // Create merged PDF
+  let mergedPdfUrl = null;
+  let previewViewed = false;
+
+  try {
+    // Show loading while merging PDF
+    Swal.fire({
+      title: 'กำลังเตรียมเอกสาร...',
+      html: 'กำลังรวมไฟล์ PDF ทั้งหมด',
+      allowOutsideClick: false,
+      showConfirmButton: false,
+      willOpen: () => {
+        Swal.showLoading();
       }
-      Swal.close();
-      } catch (error) {
-        console.error('Error creating merged PDF:', error);
-        Swal.close();
-        setMergedPdfFile(null);
-        // อย่าหยุด flow — ส่งไฟล์แยกแทน
-        Toast.fire({
-          icon: 'warning',
-          title: 'ไม่สามารถรวมไฟล์ PDF',
-          text: 'ระบบจะส่งไฟล์แยกแทน'
-        });
-        // ไม่ return false; ให้ไปต่อได้
-      }
+    });
 
-    const summaryHTML = `
+    const attachmentPdfFiles = allFiles.filter(file => file.type === 'application/pdf');
+    const pdfFiles = [];
+    if (summaryFile) {
+      pdfFiles.push(summaryFile);
+    }
+    pdfFiles.push(...attachmentPdfFiles);
+
+    if (pdfFiles.length > 0) {
+      if (pdfFiles.length > 1) {
+        // Merge multiple PDFs (robust)
+        const { blob, skipped } = await mergePDFs(pdfFiles);
+        const mergedFile = new File([blob], 'merged_documents.pdf', { type: 'application/pdf' });
+        setMergedPdfFile(mergedFile);
+        mergedPdfUrl = URL.createObjectURL(blob);
+        if (skipped?.length) {
+          Toast.fire({ icon: 'warning', title: 'ข้ามไฟล์ PDF บางไฟล์', text: skipped.join(', ') });
+        }
+      } else {
+        // Use single PDF (summary only or single attachment)
+        const single = pdfFiles[0];
+        setMergedPdfFile(single);
+        mergedPdfUrl = URL.createObjectURL(single);
+      }
+    }
+    Swal.close();
+  } catch (error) {
+    console.error('Error creating merged PDF:', error);
+    Swal.close();
+    setMergedPdfFile(null);
+    // อย่าหยุด flow — ส่งไฟล์แยกแทน
+    Toast.fire({
+      icon: 'warning',
+      title: 'ไม่สามารถรวมไฟล์ PDF',
+      text: 'ระบบจะส่งไฟล์แยกแทน'
+    });
+    // ไม่ return false; ให้ไปต่อได้
+  }
+
+  const summaryHTML = `
       <div class="text-left space-y-4">
         <div class="bg-gray-50 p-4 rounded-lg">
           <h4 class="font-semibold text-gray-700 mb-2">ข้อมูลบทความ</h4>
@@ -2054,17 +2566,13 @@ const showSubmissionConfirmation = async () => {
           <h4 class="font-semibold text-yellow-700 mb-2">เอกสารแนบ</h4>
           <div class="space-y-3 text-sm">
             <div>
-              <p class="font-medium mb-2">ไฟล์ทั้งหมด (${allFilesList.length} ไฟล์):</p>
-              <div class="bg-white p-3 rounded border max-h-32 overflow-y-auto">
+              <p class="font-medium mb-2">ไฟล์ทั้งหมด (${filesForDisplay.length} ไฟล์ รวมเอกสารที่ระบบจัดทำ)</p>
+              <div class="bg-white p-3 rounded border max-h-40 overflow-y-auto">
                 <ul class="space-y-1">
-                  ${allFilesList.map(file => `
-                    <li class="flex justify-between items-center text-xs">
-                      <span>📄 ${file.name}</span>
-                      <span class="text-gray-500">${(file.size / 1024 / 1024).toFixed(2)} MB</span>
-                    </li>
-                  `).join('')}
+                  ${fileListHtml}
                 </ul>
               </div>
+              <p class="text-xs text-gray-500 mt-2">⭐ หมายถึงเอกสารที่ระบบสร้างให้อัตโนมัติจากข้อมูลแบบฟอร์ม</p>
             </div>
 
             ${mergedPdfUrl ? `

--- a/fund-management-api/controllers/system_config.go
+++ b/fund-management-api/controllers/system_config.go
@@ -109,16 +109,19 @@ func GetSystemConfigWindow(c *gin.Context) {
 		ActivitySupportAnnouncement sql.NullInt64
 		ConferenceAnnouncement      sql.NullInt64
 		ServiceAnnouncement         sql.NullInt64
+		KkuReportYear               sql.NullString
+		Installment                 sql.NullInt64
 	}
 
 	if err := config.DB.Raw(`
-		SELECT
-		  config_id, system_version, current_year, start_date, end_date, last_updated, updated_by,
-		  main_annoucement, reward_announcement, activity_support_announcement, conference_announcement, service_announcement
-		FROM system_config
-		ORDER BY config_id DESC
-		LIMIT 1
-	`).Scan(&row).Error; err != nil {
+                SELECT
+                  config_id, system_version, current_year, start_date, end_date, last_updated, updated_by,
+                  main_annoucement, reward_announcement, activity_support_announcement, conference_announcement, service_announcement,
+                  kku_report_year, installment
+                FROM system_config
+                ORDER BY config_id DESC
+                LIMIT 1
+        `).Scan(&row).Error; err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch system_config window"})
 		return
 	}
@@ -180,6 +183,19 @@ func GetSystemConfigWindow(c *gin.Context) {
 		"conference_announcement":       toIntPtr(row.ConferenceAnnouncement),
 		"service_announcement":          toIntPtr(row.ServiceAnnouncement),
 
+		"kku_report_year": func() interface{} {
+			if row.KkuReportYear.Valid {
+				return row.KkuReportYear.String
+			}
+			return nil
+		}(),
+		"installment": func() interface{} {
+			if row.Installment.Valid {
+				return int(row.Installment.Int64)
+			}
+			return nil
+		}(),
+
 		"is_open_raw":       isOpenRaw,
 		"is_open_effective": isOpenEff,
 		"now":               now.Format(time.RFC3339Nano),
@@ -199,21 +215,24 @@ func GetSystemConfigAdmin(c *gin.Context) {
 		LastUpdated   sql.NullTime   `json:"last_updated"`
 		UpdatedBy     sql.NullInt64  `json:"updated_by"`
 
-		MainAnnoucement             sql.NullInt64 `json:"main_annoucement"`
-		RewardAnnouncement          sql.NullInt64 `json:"reward_announcement"`
-		ActivitySupportAnnouncement sql.NullInt64 `json:"activity_support_announcement"`
-		ConferenceAnnouncement      sql.NullInt64 `json:"conference_announcement"`
-		ServiceAnnouncement         sql.NullInt64 `json:"service_announcement"`
+		MainAnnoucement             sql.NullInt64  `json:"main_annoucement"`
+		RewardAnnouncement          sql.NullInt64  `json:"reward_announcement"`
+		ActivitySupportAnnouncement sql.NullInt64  `json:"activity_support_announcement"`
+		ConferenceAnnouncement      sql.NullInt64  `json:"conference_announcement"`
+		ServiceAnnouncement         sql.NullInt64  `json:"service_announcement"`
+		KkuReportYear               sql.NullString `json:"kku_report_year"`
+		Installment                 sql.NullInt64  `json:"installment"`
 	}
 
 	if err := config.DB.Raw(`
-		SELECT
-		  config_id, system_version, current_year, start_date, end_date, last_updated, updated_by,
-		  main_annoucement, reward_announcement, activity_support_announcement, conference_announcement, service_announcement
-		FROM system_config
-		ORDER BY config_id DESC
-		LIMIT 1
-	`).Scan(&row).Error; err != nil {
+                SELECT
+                  config_id, system_version, current_year, start_date, end_date, last_updated, updated_by,
+                  main_annoucement, reward_announcement, activity_support_announcement, conference_announcement, service_announcement,
+                  kku_report_year, installment
+                FROM system_config
+                ORDER BY config_id DESC
+                LIMIT 1
+        `).Scan(&row).Error; err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"success": false, "error": "failed to fetch system_config"})
 		return
 	}
@@ -272,6 +291,19 @@ func GetSystemConfigAdmin(c *gin.Context) {
 		"activity_support_announcement": toIntPtr(row.ActivitySupportAnnouncement),
 		"conference_announcement":       toIntPtr(row.ConferenceAnnouncement),
 		"service_announcement":          toIntPtr(row.ServiceAnnouncement),
+
+		"kku_report_year": func() interface{} {
+			if row.KkuReportYear.Valid {
+				return row.KkuReportYear.String
+			}
+			return nil
+		}(),
+		"installment": func() interface{} {
+			if row.Installment.Valid {
+				return int(row.Installment.Int64)
+			}
+			return nil
+		}(),
 
 		"is_open_raw":       isOpenRaw,
 		"is_open_effective": isOpenEff,


### PR DESCRIPTION
## Summary
- resolve the publication summary template path dynamically so deployments can point to an external DOCX file via env configuration or the repository root asset
- remove the duplicated DOCX from the public/templates folder to avoid pushing the binary into follow-up branches

## Testing
- npm test --prefix frontend_project_fund

------
https://chatgpt.com/codex/tasks/task_e_68d3c69aef64832a8e1002064135c7a5