### PR TITLE
Fix publication summary endpoint routing

### DIFF
--- a/frontend_project_fund/app/lib/api.js
+++ b/frontend_project_fund/app/lib/api.js
@@ -1,7 +1,58 @@
 // app/lib/api.js - Updated API Client Service for Backend Communication
+
+export const API_VERSION_PREFIX = '/api/v1';
+const API_VERSION_REGEX = /\/api\/v\d+$/i;
+const DEFAULT_BACKEND_ORIGIN = 'http://localhost:8080';
+
+const stripTrailingSlashes = (value = '') => value.replace(/\/+$/, '');
+const hasValue = (value) => typeof value === 'string' && value.trim().length > 0;
+const ensureLeadingSlash = (value = '') => {
+  if (!value) {
+    return '';
+  }
+  return value.startsWith('/') ? value : `/${value}`;
+};
+
+export const resolveApiBaseUrl = () => {
+  const candidates = [
+    process.env.NEXT_PUBLIC_API_URL,
+    process.env.NEXT_PUBLIC_BACKEND_URL,
+    process.env.BACKEND_URL,
+  ];
+
+  let selected = candidates.find(hasValue);
+
+  if (!selected) {
+    selected = `${DEFAULT_BACKEND_ORIGIN}${API_VERSION_PREFIX}`;
+  }
+
+  const normalized = stripTrailingSlashes(selected.trim());
+
+  if (API_VERSION_REGEX.test(normalized)) {
+    return normalized;
+  }
+
+  if (/\/api$/i.test(normalized)) {
+    return `${normalized}/v1`;
+  }
+
+  return `${normalized}${API_VERSION_PREFIX}`;
+};
+
+export const joinApiUrl = (path, base = resolveApiBaseUrl()) => {
+  const sanitizedBase = stripTrailingSlashes(base || '');
+  const sanitizedPath = ensureLeadingSlash(path || '');
+
+  if (!sanitizedBase) {
+    return sanitizedPath || `${API_VERSION_PREFIX}${sanitizedPath}`;
+  }
+
+  return `${sanitizedBase}${sanitizedPath}`;
+};
+
 class APIClient {
   constructor() {
-    this.baseURL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080/api/v1';
+    this.baseURL = resolveApiBaseUrl();
     console.log('API Base URL:', this.baseURL); // Debug log
     this.accessTokenKey = 'access_token';
     this.refreshTokenKey = 'refresh_token';

--- a/frontend_project_fund/app/member/components/applications/PublicationRewardForm.js
+++ b/frontend_project_fund/app/member/components/applications/PublicationRewardForm.js
@@ -5,7 +5,7 @@ import { useState, useEffect, useRef } from "react";
 import { Award, Upload, Users, FileText, Plus, X, Save, Send, AlertCircle, Search, Eye, Calculator, Signature } from "lucide-react";
 import PageLayout from "../common/PageLayout";
 import SimpleCard from "../common/SimpleCard";
-import { systemAPI, authAPI } from '../../../lib/api';
+import { systemAPI, authAPI, joinApiUrl } from '../../../lib/api';
 import {
   submissionAPI,
   publicationDetailsAPI,
@@ -58,15 +58,10 @@ const PUBLICATION_SUMMARY_ENDPOINT = (() => {
   const env = (typeof process !== 'undefined' && process?.env) ? process.env : {};
   const explicit = (env.NEXT_PUBLIC_PUBLICATION_SUMMARY_URL || '').trim();
   if (explicit) {
-    return explicit;
+    return explicit.replace(/\/+$/, '');
   }
 
-  const base = (env.NEXT_PUBLIC_API_URL || env.BACKEND_URL || '').trim();
-  if (base) {
-    return `${base.replace(/\/$/, '')}/publication-summary`;
-  }
-
-  return '/api/publication-summary';
+  return joinApiUrl('/publication-summary');
 })();
 
 // =================================================================
@@ -741,7 +736,7 @@ const generateSubmissionSummaryPdf = async ({
 
   const attempted = new Set();
   const endpoints = [PUBLICATION_SUMMARY_ENDPOINT];
-  const fallbackEndpoint = '/api/publication-summary';
+  const fallbackEndpoint = joinApiUrl('/publication-summary');
   if (!endpoints.includes(fallbackEndpoint)) {
     endpoints.push(fallbackEndpoint);
   }


### PR DESCRIPTION
## Summary
- normalize API base URL resolution to guarantee the /api/v1 prefix and export a reusable join helper
- update the publication reward form to rely on the shared helper when calling the publication summary generator

## Testing
- npm run lint *(fails: command prompts for ESLint configuration in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d53621a0f4832abbda7706d0f58aa0