### PR TITLE
Improve publication summary LibreOffice handling

### DIFF
--- a/frontend_project_fund/README.md
+++ b/frontend_project_fund/README.md
@@ -1,37 +1,21 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
+## Publication summary API
 
-## Getting Started
+The `POST /api/publication-summary` endpoint can generate a PDF document from the official DOCX template by invoking LibreOffice in headless mode. The API performs an automatic lookup for the LibreOffice CLI (`soffice`) using the current `PATH`, a set of common installation locations, and the optional environment variables listed below.
 
-First, run the development server:
+### Environment variables
 
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
-```
+| Variable | Description |
+| --- | --- |
+| `LIBREOFFICE_PATH` | Optional hint that points either to the `soffice` executable or to its containing directory. Multiple paths can be provided using the platform delimiter (`:` on Linux/macOS, `;` on Windows). |
+| `PUBLICATION_SUMMARY_FALLBACK_FORMAT` | When set to `docx`, the route returns the patched DOCX file instead of failing if LibreOffice is unavailable. |
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+If LibreOffice cannot be located the API responds with HTTP `503` and JSON `{ "error": "LIBREOFFICE_NOT_INSTALLED", ... }`. Configure `LIBREOFFICE_PATH` on platforms where LibreOffice is installed outside of the default locations (for example, a custom Windows install directory).
 
-You can start editing the page by modifying `app/page.js`. The page auto-updates as you edit the file.
+### Local testing
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+1. Install [LibreOffice](https://www.libreoffice.org/download/download-libreoffice/).
+2. Ensure the `soffice` binary is available on the system `PATH` or export `LIBREOFFICE_PATH` before starting the Next.js server.
+3. Run the dev server with `npm run dev` (or `yarn dev`).
+4. Issue a POST request with the placeholders payload to `/api/publication-summary`.
 
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
-# frontend_project_plan
+When LibreOffice is present the endpoint returns a PDF response (`Content-Type: application/pdf`). When LibreOffice is missing and the fallback is disabled, callers receive a structured JSON error without the route crashing.

--- a/frontend_project_fund/app/api/publication-summary/routes.js
+++ b/frontend_project_fund/app/api/publication-summary/routes.js
@@ -5,6 +5,7 @@ import os from 'os';
 import { randomUUID } from 'crypto';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
+import { performance } from 'perf_hooks';
 import { patchDocument, PatchType, Paragraph, TextRun } from 'docx';
 
 export const runtime = 'nodejs';
@@ -39,6 +40,31 @@ const resolveTemplatePath = async () => {
   return null;
 };
 
+const logScope = 'publication-summary';
+
+const log = (level, event, metadata = {}) => {
+  const entry = {
+    scope: logScope,
+    event,
+    timestamp: new Date().toISOString(),
+    ...metadata,
+  };
+
+  const serialized = JSON.stringify(entry);
+
+  switch (level) {
+    case 'error':
+      console.error(serialized);
+      break;
+    case 'warn':
+      console.warn(serialized);
+      break;
+    default:
+      console.log(serialized);
+      break;
+  }
+};
+
 const createParagraph = (text = '') => new Paragraph({
   children: [new TextRun({ text })],
 });
@@ -67,7 +93,42 @@ const buildPatches = (placeholders = {}, documentLines = []) => {
   return patches;
 };
 
-const candidateLibreOfficePaths = () => {
+const envDelimiter = process.platform === 'win32' ? ';' : path.delimiter;
+
+const sanitizeEnvPaths = (value = '') =>
+  value
+    .split(envDelimiter)
+    .map((candidate) => candidate.trim())
+    .filter(Boolean);
+
+const ensureSofficeExecutable = async (candidatePath) => {
+  if (!candidatePath) {
+    return [];
+  }
+
+  const normalized = path.normalize(candidatePath);
+
+  try {
+    const stats = await fs.stat(normalized);
+    if (stats.isDirectory()) {
+      const executables = process.platform === 'win32' ? ['soffice.exe'] : ['soffice', 'libreoffice'];
+      return executables.map((name) => path.join(normalized, name));
+    }
+
+    if (stats.isFile()) {
+      return [normalized];
+    }
+  } catch (error) {
+    log('warn', 'libreoffice.env_candidate.invalid', {
+      candidatePath,
+      error: error?.message,
+    });
+  }
+
+  return [normalized];
+};
+
+const defaultLibreOfficeLocations = () => {
   if (process.platform === 'win32') {
     return [
       'C:/Program Files/LibreOffice/program/soffice.exe',
@@ -76,24 +137,103 @@ const candidateLibreOfficePaths = () => {
     ];
   }
 
-  return ['soffice', 'libreoffice'];
+  const unixCandidates = [
+    '/usr/bin/soffice',
+    '/usr/local/bin/soffice',
+    '/snap/bin/libreoffice',
+    '/Applications/LibreOffice.app/Contents/MacOS/soffice',
+    'soffice',
+    'libreoffice',
+  ];
+
+  return unixCandidates;
+};
+
+const resolveOnPath = async (command) => {
+  const locator = process.platform === 'win32' ? 'where' : 'which';
+
+  try {
+    const { stdout } = await execFileAsync(locator, [command]);
+    const match = stdout
+      .split(/\r?\n/g)
+      .map((line) => line.trim())
+      .find(Boolean);
+
+    if (match) {
+      await fs.access(match);
+      return match;
+    }
+  } catch (error) {
+    log('warn', 'libreoffice.locator.failed', {
+      command,
+      locator,
+      error: error?.message,
+    });
+  }
+
+  return null;
 };
 
 const resolveLibreOffice = async () => {
-  const candidates = candidateLibreOfficePaths();
+  const envCandidates = sanitizeEnvPaths(process.env.LIBREOFFICE_PATH || '');
+  const envResolved = await Promise.all(envCandidates.map((candidate) => ensureSofficeExecutable(candidate)));
+  const flattenedEnv = envResolved.flat();
+
+  const candidates = [...flattenedEnv, ...defaultLibreOfficeLocations()];
+  const seen = new Set();
+  const attempts = [];
+
+  log('info', 'libreoffice.resolve.start', {
+    envCandidates,
+    totalCandidates: candidates.length,
+  });
+
   for (const candidate of candidates) {
-    try {
-      if (candidate.includes('/') || candidate.includes('\\') || candidate.includes(':')) {
-        await fs.access(candidate);
-        return candidate;
+    if (!candidate || seen.has(candidate)) {
+      continue;
+    }
+    seen.add(candidate);
+    const hasPathSeparators = /[\\/]/.test(candidate) || candidate.includes(':');
+    attempts.push(candidate);
+
+    if (hasPathSeparators) {
+      try {
+        const stats = await fs.stat(candidate);
+        if (stats.isFile()) {
+          log('info', 'libreoffice.resolve.success', { resolvedPath: candidate, method: 'absolute' });
+          return candidate;
+        }
+      } catch (error) {
+        log('warn', 'libreoffice.resolve.candidate_missing', {
+          candidate,
+          error: error?.message,
+        });
       }
-      await execFileAsync('which', [candidate]);
-      return candidate;
-    } catch (error) {
-      // Try the next candidate
+      continue;
+    }
+
+    const resolved = await resolveOnPath(candidate);
+    if (resolved) {
+      log('info', 'libreoffice.resolve.success', { resolvedPath: resolved, method: 'which', candidate });
+      return resolved;
     }
   }
-  throw new Error('LibreOffice CLI (soffice) not found on server');
+
+  log('error', 'libreoffice.resolve.failed', { attempts });
+  throw new Error('LIBREOFFICE_NOT_INSTALLED');
+};
+
+const readFileSafe = async (filePath) => {
+  try {
+    const data = await fs.readFile(filePath);
+    return data;
+  } catch (error) {
+    log('error', 'filesystem.read_failed', {
+      filePath,
+      error: error?.message,
+    });
+    throw error;
+  }
 };
 
 const convertDocxToPdf = async (docxBuffer) => {
@@ -101,8 +241,11 @@ const convertDocxToPdf = async (docxBuffer) => {
   const docxPath = path.join(tmpDir, `summary-${randomUUID()}.docx`);
   const pdfPath = path.join(tmpDir, `${path.parse(docxPath).name}.pdf`);
 
+  log('info', 'conversion.prepare', { tmpDir, docxPath, pdfPath });
+
   try {
     await fs.writeFile(docxPath, docxBuffer);
+    log('info', 'conversion.file_written', { docxPath, size: docxBuffer.length });
 
     let libreOffice;
     try {
@@ -113,20 +256,65 @@ const convertDocxToPdf = async (docxBuffer) => {
       throw enhancedError;
     }
 
-    await execFileAsync(libreOffice, ['--headless', '--convert-to', 'pdf', '--outdir', tmpDir, docxPath], {
-      timeout: 30000,
-    });
+    const start = performance.now();
+    try {
+      const { stdout, stderr } = await execFileAsync(
+        libreOffice,
+        ['--headless', '--norestore', '--convert-to', 'pdf', '--outdir', tmpDir, docxPath],
+        {
+          timeout: 30000,
+        },
+      );
 
-    const pdfBuffer = await fs.readFile(pdfPath);
+      log('info', 'conversion.command.completed', {
+        executable: libreOffice,
+        durationMs: Math.round(performance.now() - start),
+        stdout: stdout?.trim(),
+        stderr: stderr?.trim(),
+      });
+    } catch (error) {
+      log('error', 'conversion.command.failed', {
+        executable: libreOffice,
+        durationMs: Math.round(performance.now() - start),
+        code: error?.code,
+        signal: error?.signal,
+        stdout: error?.stdout?.trim(),
+        stderr: error?.stderr?.trim(),
+        error: error?.message,
+      });
+      throw error;
+    }
+
+    const pdfBuffer = await readFileSafe(pdfPath);
+    log('info', 'conversion.read_pdf.success', { pdfPath, size: pdfBuffer.length });
     return pdfBuffer;
   } finally {
     await fs.rm(tmpDir, { recursive: true, force: true });
+    log('info', 'conversion.cleanup.completed', { tmpDir });
   }
 };
 
 export async function POST(request) {
   try {
-    const payload = await request.json();
+    if (request.bodyUsed) {
+      log('warn', 'request.body.already_used');
+      return NextResponse.json(
+        { error: 'REQUEST_BODY_ALREADY_READ', details: 'Request body stream has already been consumed.' },
+        { status: 409 },
+      );
+    }
+
+    let payload;
+    try {
+      payload = await request.json();
+    } catch (parseError) {
+      log('error', 'request.body.parse_failed', { error: parseError?.message });
+      return NextResponse.json(
+        { error: 'INVALID_JSON', details: 'Unable to parse request body as JSON.' },
+        { status: 400 },
+      );
+    }
+
     const { placeholders, documentLines } = payload || {};
 
     if (!placeholders || typeof placeholders !== 'object') {
@@ -139,7 +327,7 @@ export async function POST(request) {
       return NextResponse.json({ error: 'TEMPLATE_NOT_AVAILABLE' }, { status: 503 });
     }
 
-    const templateBuffer = await fs.readFile(templatePath);
+    const templateBuffer = await readFileSafe(templatePath);
     const patches = buildPatches(placeholders, documentLines);
 
     const patchedDocx = await patchDocument({
@@ -159,9 +347,24 @@ export async function POST(request) {
         },
       });
     } catch (conversionError) {
-      console.error('DOCX to PDF conversion failed:', conversionError);
+      log('error', 'conversion.failed', {
+        error: conversionError?.message,
+        code: conversionError?.code,
+      });
 
       if (conversionError?.message === 'LIBREOFFICE_NOT_INSTALLED') {
+        if (process.env.PUBLICATION_SUMMARY_FALLBACK_FORMAT === 'docx') {
+          log('warn', 'conversion.fallback_to_docx');
+          return new NextResponse(patchedDocx, {
+            status: 200,
+            headers: {
+              'Content-Type':
+                'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+              'Content-Disposition': 'attachment; filename="publication-summary.docx"',
+            },
+          });
+        }
+
         return NextResponse.json(
           {
             error: 'LIBREOFFICE_NOT_INSTALLED',
@@ -178,7 +381,7 @@ export async function POST(request) {
       );
     }
   } catch (error) {
-    console.error('Failed to generate publication summary document:', error);
+    log('error', 'summary.generation_failed', { error: error?.message });
     return NextResponse.json({ error: 'SUMMARY_GENERATION_FAILED', details: error.message }, { status: 500 });
   }
 }


### PR DESCRIPTION
## Summary
- add structured logging and robust LibreOffice CLI resolution for the publication summary API
- fall back gracefully when LibreOffice is missing and optionally return the DOCX when configured
- document the new environment variables required to configure the publication summary conversion

## Testing
- `npm run lint` *(fails: command prompts for ESLint configuration and cannot run non-interactively)*

------
https://chatgpt.com/codex/tasks/task_e_68d547f74f84832a94f6b3a8f8635b8e