### PR TITLE
Add department head review flow

### DIFF
--- a/frontend_project_fund/app/lib/dept_head_submission_api.js
+++ b/frontend_project_fund/app/lib/dept_head_submission_api.js
@@ -1,0 +1,30 @@
+// app/lib/dept_head_submission_api.js
+import apiClient from "./api";
+
+export const deptHeadSubmissionAPI = {
+  async list(params = {}) {
+    return apiClient.get("/dept-head/submissions", params);
+  },
+
+  async getSubmissionDetails(submissionId) {
+    return apiClient.get(`/dept-head/submissions/${submissionId}/details`);
+  },
+
+  async recommendSubmission(submissionId, payload = {}) {
+    return apiClient.post(`/dept-head/submissions/${submissionId}/recommend`, payload);
+  },
+
+  async rejectSubmission(submissionId, payload = {}) {
+    return apiClient.post(`/dept-head/submissions/${submissionId}/reject`, payload);
+  },
+
+  async getSubmissionDocuments(submissionId, params = {}) {
+    return apiClient.get(`/submissions/${submissionId}/documents`, params);
+  },
+
+  async getDocumentTypes(params = {}) {
+    return apiClient.get("/document-types", params);
+  },
+};
+
+export default deptHeadSubmissionAPI;

--- a/frontend_project_fund/app/lib/member_api.js
+++ b/frontend_project_fund/app/lib/member_api.js
@@ -10,7 +10,7 @@ import {
   submissionUtils,
 } from './teacher_api';
 import staffAPI from './staff_api';
-import apiClient from './api';
+import deptHeadSubmissionAPI from './dept_head_submission_api';
 
 const ROLE_NAME_BY_ID = {
   1: 'teacher',
@@ -34,15 +34,28 @@ const resolveRoleName = (role) => {
 
 export const deptHeadAPI = {
   async getPendingReviews(params = {}) {
-    return apiClient.get('/dept-head/submissions', params);
+    const query = { status_code: '5', ...params };
+    return deptHeadSubmissionAPI.list(query);
+  },
+
+  async getSubmissionDetails(submissionId) {
+    return deptHeadSubmissionAPI.getSubmissionDetails(submissionId);
   },
 
   async recommendSubmission(submissionId, payload = {}) {
-    return apiClient.post(`/dept-head/submissions/${submissionId}/recommend`, payload);
+    return deptHeadSubmissionAPI.recommendSubmission(submissionId, payload);
   },
 
   async rejectSubmission(submissionId, payload = {}) {
-    return apiClient.post(`/dept-head/submissions/${submissionId}/reject`, payload);
+    return deptHeadSubmissionAPI.rejectSubmission(submissionId, payload);
+  },
+
+  async getSubmissionDocuments(submissionId, params = {}) {
+    return deptHeadSubmissionAPI.getSubmissionDocuments(submissionId, params);
+  },
+
+  async getDocumentTypes(params = {}) {
+    return deptHeadSubmissionAPI.getDocumentTypes(params);
   },
 };
 

--- a/frontend_project_fund/app/member/components/dept/DeptHeadReview.js
+++ b/frontend_project_fund/app/member/components/dept/DeptHeadReview.js
@@ -1,156 +1,130 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
-import { ClipboardList, Loader2 } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { ClipboardList, Loader2, RefreshCcw } from "lucide-react";
 import PageLayout from "../common/PageLayout";
 import Card from "../common/Card";
 import DataTable from "../common/DataTable";
 import StatusBadge from "../common/StatusBadge";
-import { deptHeadAPI } from "../../../lib/member_api";
-import { statusService } from "../../../lib/status_service";
+import { deptHeadSubmissionAPI } from "@/app/lib/dept_head_submission_api";
+import { toast } from "react-hot-toast";
 
 const formatDate = (value) => {
-  if (!value) {
-    return "-";
-  }
+  if (!value) return "-";
   try {
-    return new Date(value).toLocaleString("th-TH", {
-      dateStyle: "medium",
-      timeStyle: "short",
+    const date = new Date(value);
+    return date.toLocaleString("th-TH", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
     });
   } catch (error) {
     return value;
   }
 };
 
-const STATUS_LABELS = {
-  pending: "อยู่ระหว่างการพิจารณาจากหัวหน้าสาขา",
-  recommended: "เห็นควรพิจารณาจากหัวหน้าสาขา",
-  rejected: "ไม่เห็นควรพิจารณา",
+const extractSubmissionRows = (payload) => {
+  if (!payload) return [];
+  const rows = payload.submissions || payload.data || payload.items || [];
+  return rows.map((item) => {
+    const status = item.status || item.Status || null;
+    const categoryName =
+      item.category_name ||
+      item.category?.category_name ||
+      item.Category?.category_name ||
+      "-";
+    const subcategoryName =
+      item.subcategory_name ||
+      item.subcategory?.subcategory_name ||
+      item.Subcategory?.subcategory_name ||
+      "-";
+    const applicant =
+      item.applicant_name ||
+      item.applicant ||
+      item.user?.full_name ||
+      `${item.user?.user_fname || ""} ${item.user?.user_lname || ""}`.trim() ||
+      "-";
+
+    return {
+      id: item.submission_id || item.id,
+      submission_number: item.submission_number || item.request_number || "-",
+      submission_type: item.submission_type || item.type || "fund_application",
+      status_id: item.status_id || status?.application_status_id,
+      status,
+      applicant,
+      category: categoryName,
+      subcategory: subcategoryName,
+      submitted_at:
+        item.submitted_at ||
+        item.submission_date ||
+        item.created_at ||
+        item.SubmittedAt,
+    };
+  });
 };
 
 export default function DeptHeadReview() {
-  const [submissions, setSubmissions] = useState([]);
+  const router = useRouter();
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  const [actionTarget, setActionTarget] = useState(null);
-  const [actionComment, setActionComment] = useState("");
-  const [actionLoading, setActionLoading] = useState(false);
-  const [actionError, setActionError] = useState(null);
-  const statusCacheRef = useRef(null);
+  const [rows, setRows] = useState([]);
+  const [refreshing, setRefreshing] = useState(false);
 
-  const resolveDeptStatuses = async () => {
-    if (statusCacheRef.current) {
-      return statusCacheRef.current;
-    }
-
-    const statuses = await statusService.fetchAll();
-    const findByName = (label) =>
-      statuses.find((status) => status?.status_name === label);
-
-    const pending = findByName(STATUS_LABELS.pending);
-    const recommended = findByName(STATUS_LABELS.recommended);
-    const rejected = findByName(STATUS_LABELS.rejected);
-
-    if (!pending) {
-      throw new Error(`ไม่พบสถานะ "${STATUS_LABELS.pending}"`);
-    }
-    if (!recommended) {
-      throw new Error(`ไม่พบสถานะ "${STATUS_LABELS.recommended}"`);
-    }
-    if (!rejected) {
-      throw new Error(`ไม่พบสถานะ "${STATUS_LABELS.rejected}"`);
-    }
-
-    const toId = (status) => {
-      if (!status) return undefined;
-      const rawId = status.application_status_id ?? status.status_id ?? status.id;
-      const numericId = Number(rawId);
-      return Number.isFinite(numericId) ? numericId : undefined;
-    };
-
-    const info = {
-      pending,
-      recommended,
-      rejected,
-      pendingId: toId(pending),
-      recommendedId: toId(recommended),
-      rejectedId: toId(rejected),
-    };
-
-    if (!info.pendingId || !info.recommendedId || !info.rejectedId) {
-      throw new Error("ไม่สามารถระบุรหัสสถานะหัวหน้าสาขาได้");
-    }
-
-    statusCacheRef.current = info;
-    return info;
-  };
-
-  const loadSubmissions = async () => {
+  const loadRows = async () => {
+    setLoading(true);
+    setError(null);
     try {
-      setLoading(true);
-      setError(null);
-      const statusInfo = await resolveDeptStatuses();
-      const response = await deptHeadAPI.getPendingReviews({ status_id: statusInfo.pendingId });
-      const rows = response?.submissions || response?.data || [];
-
-      const normalized = rows
-        .filter((item) => {
-          const itemStatusId = Number(
-            item.status_id ??
-            item.status?.application_status_id ??
-            item.status?.status_id ??
-            item.status?.id
-          );
-          return Number.isFinite(itemStatusId)
-            ? itemStatusId === statusInfo.pendingId
-            : true;
-        })
-        .map((item) => ({
-          id: item.submission_id || item.id,
-          submission_number: item.submission_number || item.request_number || "-",
-          category: item.category_name || item.category?.category_name || "-",
-          subcategory: item.subcategory_name || item.subcategory?.subcategory_name || "-",
-          applicant:
-          item.applicant_name ||
-          item.user?.full_name ||
-          `${item.user?.user_fname || ""} ${item.user?.user_lname || ""}`.trim() ||
-          "-",
-        submitted_at: item.submitted_at || item.created_at,
-        status:
-          item.status?.status_name ||
-          item.status_name ||
-          item.status ||
-          "รอพิจารณา",
-        raw: item,
-      }));
-
-      setSubmissions(normalized);
+      const response = await deptHeadSubmissionAPI.list({ status_code: "5" });
+      setRows(extractSubmissionRows(response));
     } catch (err) {
-      console.error("Error loading dept head submissions:", err);
+      console.error("Failed to load dept head submissions", err);
       setError(err?.message || "ไม่สามารถโหลดรายการคำร้องได้");
-      setSubmissions([]);
+      setRows([]);
     } finally {
       setLoading(false);
     }
   };
 
   useEffect(() => {
-    loadSubmissions();
+    loadRows();
   }, []);
+
+  const handleRefresh = async () => {
+    try {
+      setRefreshing(true);
+      await loadRows();
+      toast.success("อัปเดตรายการล่าสุดแล้ว");
+    } catch (err) {
+      // loadRows already handles error state
+    } finally {
+      setRefreshing(false);
+    }
+  };
 
   const columns = useMemo(
     () => [
       {
         header: "เลขคำร้อง",
         accessor: "submission_number",
+        render: (value, row) => (
+          <Link
+            href={`/member/dept-review/${row.id}`}
+            className="text-blue-600 hover:underline"
+          >
+            {value || "-"}
+          </Link>
+        ),
       },
       {
         header: "ประเภททุน",
         accessor: "category",
       },
       {
-        header: "หมวด/ทุนย่อย",
+        header: "ทุนย่อย",
         accessor: "subcategory",
       },
       {
@@ -164,183 +138,61 @@ export default function DeptHeadReview() {
       },
       {
         header: "สถานะ",
-        accessor: "status",
-        render: (value) => <StatusBadge status={value} />,
+        accessor: "status_id",
+        render: (value, row) => (
+          <StatusBadge statusId={value} fallbackLabel={row.status?.status_name} />
+        ),
       },
       {
-        header: "ดำเนินการ",
+        header: "รายละเอียด",
         accessor: "actions",
         render: (_, row) => (
-          <div className="flex gap-2">
-            <button
-              onClick={() => openAction(row, "recommend")}
-              className="px-3 py-1 text-sm rounded-md border border-blue-200 text-blue-700 hover:bg-blue-50"
-            >
-              เห็นควร/ส่งต่อ Admin
-            </button>
-            <button
-              onClick={() => openAction(row, "reject")}
-              className="px-3 py-1 text-sm rounded-md border border-red-200 text-red-600 hover:bg-red-50"
-            >
-              ปฏิเสธ
-            </button>
-          </div>
+          <button
+            onClick={() => router.push(`/member/dept-review/${row.id}`)}
+            className="inline-flex items-center gap-2 px-3 py-1.5 text-sm text-blue-600 border border-blue-200 rounded-md hover:bg-blue-50"
+          >
+            ดูรายละเอียด
+          </button>
         ),
       },
     ],
-    []
+    [router]
   );
-
-  const openAction = (row, action) => {
-    setActionTarget({ ...row, action });
-    setActionComment("");
-    setActionError(null);
-  };
-
-  const closeAction = () => {
-    setActionTarget(null);
-    setActionComment("");
-    setActionError(null);
-  };
-
-  const confirmAction = async () => {
-    if (!actionTarget) return;
-    setActionLoading(true);
-    setActionError(null);
-    try {
-      const statusInfo = await resolveDeptStatuses();
-      const basePayload = {
-        comment: actionComment?.trim() ? actionComment.trim() : undefined,
-        reviewed_at: new Date().toISOString(),
-      };
-
-      if (actionTarget.action === "recommend") {
-        await deptHeadAPI.recommendSubmission(actionTarget.id, {
-          ...basePayload,
-          status_id: statusInfo.recommendedId,
-        });
-      } else {
-        await deptHeadAPI.rejectSubmission(actionTarget.id, {
-          ...basePayload,
-          status_id: statusInfo.rejectedId,
-        });
-      }
-      closeAction();
-      await loadSubmissions();
-    } catch (err) {
-      console.error("Dept review action failed:", err);
-      setActionError(err?.message || "ไม่สามารถดำเนินการได้");
-    } finally {
-      setActionLoading(false);
-    }
-  };
 
   return (
     <PageLayout
-      title="พิจารณาคำร้อง (สาขา)"
-      subtitle="ตรวจสอบและส่งต่อคำร้องไปยังผู้ดูแลระบบ"
+      title="พิจารณาคำร้อง (หัวหน้าสาขา)"
+      subtitle="ตรวจสอบคำร้องที่อยู่ระหว่างการพิจารณาของหัวหน้าสาขา"
       icon={ClipboardList}
       breadcrumbs={[
         { label: "หน้าแรก", href: "/member" },
-        { label: "พิจารณาคำร้อง (สาขา)" },
+        { label: "พิจารณาคำร้อง (หัวหน้าสาขา)" },
       ]}
+      actions={
+        <button
+          onClick={handleRefresh}
+          disabled={refreshing}
+          className="inline-flex items-center gap-2 px-3 py-2 text-sm border border-gray-200 rounded-md text-gray-700 hover:bg-gray-50 disabled:opacity-60"
+        >
+          <RefreshCcw size={16} className={refreshing ? "animate-spin" : ""} /> รีเฟรช
+        </button>
+      }
     >
-      <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6 mb-6">
-        <div className="flex items-center justify-between gap-4">
-          <div>
-            <h3 className="text-lg font-semibold text-gray-800">รายการคำร้องที่รอตรวจสอบ</h3>
-            <p className="text-sm text-gray-500 mt-1">
-              เลือกดำเนินการเพื่อเห็นควรและส่งต่อ หรือปฏิเสธพร้อมระบุเหตุผล
-            </p>
-          </div>
-          <button
-            onClick={loadSubmissions}
-            className="px-3 py-1 text-sm rounded-md border border-gray-200 text-gray-700 hover:bg-gray-50"
-          >
-            รีเฟรชรายการ
-          </button>
-        </div>
-      </div>
-
       <Card collapsible={false}>
         {loading ? (
-          <div className="flex items-center justify-center py-16 text-gray-600">
-            <Loader2 className="animate-spin mr-2" />
-            กำลังโหลดข้อมูล...
+          <div className="flex items-center justify-center py-16 text-gray-500">
+            <Loader2 className="animate-spin mr-2" /> กำลังโหลดข้อมูล...
           </div>
         ) : error ? (
-          <div className="py-16 text-center text-red-600">{error}</div>
+          <div className="text-center text-red-600 py-16">{error}</div>
+        ) : rows.length === 0 ? (
+          <div className="text-center text-gray-500 py-16">
+            ไม่มีคำร้องที่รอพิจารณาในขณะนี้
+          </div>
         ) : (
-          <DataTable
-            columns={columns}
-            data={submissions}
-            emptyMessage="ไม่มีคำร้องที่รอพิจารณา"
-          />
+          <DataTable columns={columns} data={rows} emptyMessage="ไม่มีคำร้องที่รอพิจารณา" />
         )}
       </Card>
-
-      {actionTarget && (
-        <div className="fixed inset-0 bg-black/40 z-50 flex items-center justify-center p-4">
-          <div className="bg-white rounded-xl shadow-xl w-full max-w-lg">
-            <div className="px-6 py-4 border-b">
-              <h3 className="text-lg font-semibold text-gray-800">
-                {actionTarget.action === "recommend" ? "เห็นควร/ส่งต่อ Admin" : "ปฏิเสธคำร้อง"}
-              </h3>
-              <p className="text-sm text-gray-500 mt-1">
-                เลขคำร้อง {actionTarget.submission_number}
-              </p>
-            </div>
-
-            <div className="px-6 py-4 space-y-4">
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-2">
-                  ความคิดเห็นเพิ่มเติม
-                </label>
-                <textarea
-                  value={actionComment}
-                  onChange={(event) => setActionComment(event.target.value)}
-                  rows={4}
-                  className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  placeholder="ระบุเหตุผลหรือข้อมูลเพิ่มเติม (ถ้ามี)"
-                />
-              </div>
-              {actionError && (
-                <div className="text-sm text-red-600">{actionError}</div>
-              )}
-            </div>
-
-            <div className="px-6 py-4 border-t flex justify-end gap-3">
-              <button
-                onClick={closeAction}
-                disabled={actionLoading}
-                className="px-4 py-2 text-sm rounded-md border border-gray-300 text-gray-600 hover:bg-gray-50 disabled:opacity-60"
-              >
-                ยกเลิก
-              </button>
-              <button
-                onClick={confirmAction}
-                disabled={actionLoading}
-                className={`px-4 py-2 text-sm rounded-md text-white ${
-                  actionTarget.action === "recommend"
-                    ? "bg-blue-600 hover:bg-blue-700"
-                    : "bg-red-600 hover:bg-red-700"
-                } disabled:opacity-60`}
-              >
-                {actionLoading ? (
-                  <span className="flex items-center gap-2">
-                    <Loader2 className="animate-spin" size={16} />
-                    กำลังบันทึก...
-                  </span>
-                ) : actionTarget.action === "recommend" ? (
-                  "เห็นควร/ส่งต่อ"
-                ) : (
-                  "ปฏิเสธ"
-                )}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
     </PageLayout>
   );
 }

--- a/frontend_project_fund/app/member/components/dept/details/DeptHeadSubmissionDetails.js
+++ b/frontend_project_fund/app/member/components/dept/details/DeptHeadSubmissionDetails.js
@@ -1,0 +1,900 @@
+"use client";
+
+import React, { useEffect, useRef, useState } from "react";
+import {
+  ArrowLeft,
+  Bookmark,
+  Download,
+  Eye,
+  FileText,
+  Loader2,
+  Send,
+  Users,
+  XCircle,
+} from "lucide-react";
+import { useRouter } from "next/navigation";
+import PageLayout from "../../common/PageLayout";
+import Card from "../../common/Card";
+import StatusBadge from "../../common/StatusBadge";
+import { deptHeadSubmissionAPI } from "@/app/lib/dept_head_submission_api";
+import apiClient from "@/app/lib/api";
+import { formatCurrency } from "@/app/utils/format";
+import { toast } from "react-hot-toast";
+import Swal from "sweetalert2";
+import "sweetalert2/dist/sweetalert2.min.css";
+import { PDFDocument } from "pdf-lib";
+
+const formatDateTime = (value) => {
+  if (!value) return "-";
+  try {
+    const date = new Date(value);
+    return date.toLocaleString("th-TH", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  } catch (error) {
+    return value;
+  }
+};
+
+const formatDate = (value) => {
+  if (!value) return "-";
+  try {
+    const date = new Date(value);
+    return date.toLocaleDateString("th-TH", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+    });
+  } catch (error) {
+    return value;
+  }
+};
+
+const getApplicant = (submission) => {
+  if (!submission) return null;
+  const candidate =
+    submission.applicant ||
+    submission.applicant_user ||
+    submission.user ||
+    submission.User;
+  if (candidate) return candidate;
+
+  const submissionUsers = submission.submission_users || [];
+  const applicantUser = submissionUsers.find(
+    (user) => user.is_applicant || user.IsApplicant || user.role === "owner"
+  );
+  return applicantUser?.user || applicantUser?.User || null;
+};
+
+const getUserFullName = (user) => {
+  if (!user) return "-";
+  const firstName =
+    user.user_fname || user.first_name || user.full_name?.split(" ")[0] || "";
+  const lastName =
+    user.user_lname ||
+    user.last_name ||
+    user.full_name?.split(" ").slice(1).join(" ") ||
+    "";
+  const full = `${firstName} ${lastName}`.trim();
+  return full || user.full_name || user.email || "-";
+};
+
+const normalizeDetail = (submission, payload) => {
+  if (!submission) return { type: "unknown", data: null };
+
+  if (payload?.details?.type && payload?.details?.data) {
+    return payload.details;
+  }
+
+  if (submission.fund_application_detail || submission.FundApplicationDetail) {
+    return {
+      type: "fund_application",
+      data: submission.fund_application_detail || submission.FundApplicationDetail,
+    };
+  }
+
+  if (
+    submission.publication_reward_detail ||
+    submission.PublicationRewardDetail
+  ) {
+    return {
+      type: "publication_reward",
+      data:
+        submission.publication_reward_detail ||
+        submission.PublicationRewardDetail,
+    };
+  }
+
+  if (submission.submission_type === "publication_reward") {
+    return { type: "publication_reward", data: null };
+  }
+
+  return {
+    type: submission.submission_type || payload?.details?.type || "fund_application",
+    data: payload?.details?.data || null,
+  };
+};
+
+const mapDocumentTypeNames = (documents = [], types = []) => {
+  if (!Array.isArray(documents) || documents.length === 0) return [];
+
+  const typeMap = new Map();
+  types.forEach((type) => {
+    const id = type?.document_type_id ?? type?.id;
+    if (id != null) {
+      typeMap.set(String(id), type?.document_type_name || type?.name || type?.label);
+    }
+  });
+
+  return documents.map((doc, index) => {
+    const fileId =
+      doc.file_id ?? doc.File?.file_id ?? doc.file?.file_id ?? doc.id ?? null;
+    const typeId =
+      doc.document_type_id ??
+      doc.DocumentTypeID ??
+      doc.doc_type_id ??
+      doc.document_type?.document_type_id ??
+      null;
+    const typeName =
+      doc.document_type_name ||
+      doc.DocumentType?.document_type_name ||
+      doc.document_type?.document_type_name ||
+      (typeId != null ? typeMap.get(String(typeId)) : null);
+
+    const originalName =
+      doc.original_name ||
+      doc.original_filename ||
+      doc.file_name ||
+      doc.File?.original_name ||
+      doc.file?.original_name ||
+      `เอกสารที่ ${index + 1}`;
+
+    return {
+      ...doc,
+      file_id: fileId,
+      document_type_id: typeId,
+      document_type_name: typeName || "ไม่ระบุประเภท",
+      original_name: originalName,
+    };
+  });
+};
+
+function FundApplicationSection({ submission, detail }) {
+  if (!detail) {
+    return (
+      <Card title="รายละเอียดคำร้อง" icon={FileText} collapsible={false}>
+        <p className="text-gray-500 text-sm">ไม่พบรายละเอียดคำร้อง</p>
+      </Card>
+    );
+  }
+
+  const requestedAmount = detail.requested_amount ?? detail.requestAmount;
+  const approvedAmount = detail.approved_amount ?? detail.approvedAmount;
+  const comment = detail.comment ?? detail.Comment;
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <Card title="ข้อมูลโครงการ" icon={Bookmark} collapsible={false}>
+        <div className="space-y-4 text-sm text-gray-700">
+          <div>
+            <p className="text-gray-500">ชื่อโครงการ</p>
+            <p className="font-semibold text-gray-900">
+              {detail.project_title || detail.ProjectTitle || "-"}
+            </p>
+          </div>
+          <div>
+            <p className="text-gray-500">วัตถุประสงค์ / รายละเอียด</p>
+            <p className="whitespace-pre-wrap">
+              {detail.project_description || detail.ProjectDescription || "-"}
+            </p>
+          </div>
+        </div>
+      </Card>
+
+      <Card title="งบประมาณ" icon={FileText} collapsible={false}>
+        <div className="space-y-4 text-sm text-gray-700">
+          <div className="flex justify-between">
+            <span className="text-gray-500">จำนวนเงินที่ขอ</span>
+            <span className="font-semibold text-blue-600">
+              ฿{formatCurrency(requestedAmount || 0)}
+            </span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-gray-500">จำนวนเงินที่อนุมัติ</span>
+            <span className="font-semibold text-green-600">
+              {approvedAmount != null
+                ? `฿${formatCurrency(approvedAmount || 0)}`
+                : "-"}
+            </span>
+          </div>
+          {comment ? (
+            <div>
+              <p className="text-gray-500 mb-1">หมายเหตุ</p>
+              <p className="bg-gray-50 border border-gray-100 rounded-lg p-3 text-gray-700 whitespace-pre-wrap">
+                {comment}
+              </p>
+            </div>
+          ) : null}
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+function PublicationRewardSection({ detail }) {
+  if (!detail) {
+    return (
+      <Card title="รายละเอียดบทความ" icon={FileText} collapsible={false}>
+        <p className="text-gray-500 text-sm">ไม่พบรายละเอียดบทความ</p>
+      </Card>
+    );
+  }
+
+  const rewardAmount = detail.reward_amount ?? detail.RewardAmount;
+  const approveReward = detail.reward_approve_amount ?? detail.RewardApproveAmount;
+  const revisionFee = detail.revision_fee ?? detail.RevisionFee;
+  const approveRevision =
+    detail.revision_fee_approve_amount ?? detail.RevisionFeeApproveAmount;
+  const publicationFee = detail.publication_fee ?? detail.PublicationFee;
+  const approvePublication =
+    detail.publication_fee_approve_amount ?? detail.PublicationFeeApproveAmount;
+  const totalApprove = detail.total_approve_amount ?? detail.TotalApproveAmount;
+  const totalAmount = detail.total_amount ?? detail.TotalAmount;
+  const rejectionReason = detail.rejection_reason ?? detail.RejectionReason;
+  const approvalComment = detail.approval_comment ?? detail.ApprovalComment;
+
+  return (
+    <div className="space-y-6">
+      <Card title="ข้อมูลบทความ" icon={Bookmark} collapsible={false}>
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 text-sm text-gray-700">
+          <div>
+            <p className="text-gray-500">ชื่อบทความ</p>
+            <p className="font-semibold text-gray-900">
+              {detail.paper_title || detail.PaperTitle || "-"}
+            </p>
+          </div>
+          <div>
+            <p className="text-gray-500">วารสาร / แหล่งตีพิมพ์</p>
+            <p className="font-semibold text-gray-900">
+              {detail.journal_name || detail.JournalName || "-"}
+            </p>
+          </div>
+          <div>
+            <p className="text-gray-500">วันที่ตีพิมพ์</p>
+            <p>{formatDate(detail.publication_date || detail.PublicationDate)}</p>
+          </div>
+          <div>
+            <p className="text-gray-500">ประเภทบทความ</p>
+            <p>{detail.publication_type || detail.PublicationType || "-"}</p>
+          </div>
+          <div>
+            <p className="text-gray-500">Quartile</p>
+            <p>{detail.quartile || detail.Quartile || "-"}</p>
+          </div>
+          <div>
+            <p className="text-gray-500">DOI / ลิงก์</p>
+            <p>{detail.doi || detail.DOI || detail.url || detail.URL || "-"}</p>
+          </div>
+        </div>
+      </Card>
+
+      <Card title="รายละเอียดเงินรางวัล" icon={FileText} collapsible={false}>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm text-gray-700">
+          <div className="flex justify-between">
+            <span className="text-gray-500">เงินรางวัล (ฐาน)</span>
+            <span className="font-semibold">฿{formatCurrency(rewardAmount || 0)}</span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-gray-500">เงินรางวัล (เสนออนุมัติ)</span>
+            <span className="font-semibold text-blue-600">
+              {approveReward != null
+                ? `฿${formatCurrency(approveReward || 0)}`
+                : "-"}
+            </span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-gray-500">ค่าปรับปรุง</span>
+            <span className="font-semibold">฿{formatCurrency(revisionFee || 0)}</span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-gray-500">ค่าปรับปรุง (เสนออนุมัติ)</span>
+            <span className="font-semibold text-blue-600">
+              {approveRevision != null
+                ? `฿${formatCurrency(approveRevision || 0)}`
+                : "-"}
+            </span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-gray-500">ค่าตีพิมพ์</span>
+            <span className="font-semibold">฿{formatCurrency(publicationFee || 0)}</span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-gray-500">ค่าตีพิมพ์ (เสนออนุมัติ)</span>
+            <span className="font-semibold text-blue-600">
+              {approvePublication != null
+                ? `฿${formatCurrency(approvePublication || 0)}`
+                : "-"}
+            </span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-gray-500">ยอดรวม</span>
+            <span className="font-semibold">฿{formatCurrency(totalAmount || 0)}</span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-gray-500">ยอดรวมที่เสนออนุมัติ</span>
+            <span className="font-semibold text-blue-600">
+              {totalApprove != null
+                ? `฿${formatCurrency(totalApprove || 0)}`
+                : "-"}
+            </span>
+          </div>
+        </div>
+        {approvalComment ? (
+          <div className="mt-4">
+            <p className="text-gray-500 mb-1">หมายเหตุ</p>
+            <p className="bg-gray-50 border border-gray-100 rounded-lg p-3 text-gray-700 whitespace-pre-wrap">
+              {approvalComment}
+            </p>
+          </div>
+        ) : null}
+        {rejectionReason ? (
+          <div className="mt-4">
+            <p className="text-gray-500 mb-1">เหตุผลการไม่อนุมัติ</p>
+            <p className="bg-red-50 border border-red-100 rounded-lg p-3 text-red-700 whitespace-pre-wrap">
+              {rejectionReason}
+            </p>
+          </div>
+        ) : null}
+      </Card>
+    </div>
+  );
+}
+
+function SubmissionTeamCard({ submissionUsers = [] }) {
+  if (!submissionUsers.length) {
+    return null;
+  }
+
+  return (
+    <Card title="ผู้เกี่ยวข้อง" icon={Users} collapsible={false}>
+      <div className="divide-y divide-gray-200">
+        {submissionUsers.map((item) => {
+          const user = item.user || item.User || item;
+          const roleLabel = item.role || item.Role || "สมาชิก";
+          return (
+            <div
+              key={`${item.user_id || user?.user_id || user?.id}-${roleLabel}`}
+              className="py-3 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2"
+            >
+              <div>
+                <p className="font-semibold text-gray-900">
+                  {getUserFullName(user)}
+                </p>
+                <p className="text-sm text-gray-500">{user?.email || ""}</p>
+              </div>
+              <span className="inline-flex items-center px-3 py-1 text-xs font-medium rounded-full bg-gray-100 text-gray-700">
+                {roleLabel}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </Card>
+  );
+}
+
+function AttachmentsCard({
+  submission,
+  attachments,
+  onView,
+  onDownload,
+  onViewMerged,
+  onDownloadMerged,
+  loading,
+  merging,
+  creatingMerged,
+}) {
+  return (
+    <Card title="เอกสารแนบ" icon={FileText} collapsible={false}>
+      <div className="space-y-6">
+        {loading ? (
+          <div className="flex items-center justify-center py-10 text-gray-500">
+            <Loader2 className="animate-spin mr-2" /> กำลังโหลดเอกสาร...
+          </div>
+        ) : attachments.length ? (
+          <div className="space-y-4">
+            {attachments.map((doc, index) => (
+              <div
+                key={doc.document_id || doc.file_id || index}
+                className="bg-gray-50 rounded-lg p-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4"
+              >
+                <div className="flex items-start gap-4">
+                  <div className="w-10 h-10 rounded-full bg-white border border-gray-200 flex items-center justify-center text-sm font-semibold text-gray-600">
+                    {index + 1}
+                  </div>
+                  <div>
+                    <p className="font-semibold text-gray-900" title={doc.original_name}>
+                      {doc.original_name}
+                    </p>
+                    <p className="text-sm text-gray-500">
+                      {doc.document_type_name || "ไม่ระบุประเภท"}
+                    </p>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <button
+                    onClick={() => onView(doc.file_id)}
+                    className="inline-flex items-center gap-1 px-3 py-2 text-sm text-blue-600 border border-blue-200 rounded-md hover:bg-blue-50 disabled:opacity-50"
+                    disabled={!doc.file_id}
+                  >
+                    <Eye size={16} /> ดู
+                  </button>
+                  <button
+                    onClick={() => onDownload(doc.file_id, doc.original_name)}
+                    className="inline-flex items-center gap-1 px-3 py-2 text-sm text-green-600 border border-green-200 rounded-md hover:bg-green-50 disabled:opacity-50"
+                    disabled={!doc.file_id}
+                  >
+                    <Download size={16} /> ดาวน์โหลด
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="text-center py-10 text-gray-500">
+            ไม่พบเอกสารที่แนบไว้
+          </div>
+        )}
+
+        {attachments.length ? (
+          <div className="flex flex-wrap gap-2 justify-end border-t border-gray-100 pt-4">
+            <button
+              onClick={onViewMerged}
+              className="inline-flex items-center gap-2 px-4 py-2 text-sm text-blue-600 border border-blue-200 rounded-md hover:bg-blue-50 disabled:opacity-50"
+              disabled={merging || creatingMerged || !attachments.length}
+            >
+              <Eye size={16} /> ดูไฟล์รวม
+            </button>
+            <button
+              onClick={onDownloadMerged}
+              className="inline-flex items-center gap-2 px-4 py-2 text-sm text-green-600 border border-green-200 rounded-md hover:bg-green-50 disabled:opacity-50"
+              disabled={merging || creatingMerged || !attachments.length}
+            >
+              <Download size={16} /> ดาวน์โหลดไฟล์รวม
+            </button>
+          </div>
+        ) : null}
+      </div>
+    </Card>
+  );
+}
+
+function ActionPanel({ onRecommend, onReject, disabled }) {
+  return (
+    <Card title="การดำเนินการ" icon={Send} collapsible={false}>
+      <div className="flex flex-col sm:flex-row gap-3 sm:items-center sm:justify-end">
+        <button
+          onClick={onRecommend}
+          disabled={disabled}
+          className="inline-flex items-center justify-center gap-2 px-4 py-2 text-sm font-semibold rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-60"
+        >
+          <Send size={16} /> เห็นควรพิจารณา
+        </button>
+        <button
+          onClick={onReject}
+          disabled={disabled}
+          className="inline-flex items-center justify-center gap-2 px-4 py-2 text-sm font-semibold rounded-md bg-red-600 text-white hover:bg-red-700 disabled:opacity-60"
+        >
+          <XCircle size={16} /> ไม่เห็นควรพิจารณา
+        </button>
+      </div>
+    </Card>
+  );
+}
+
+export default function DeptHeadSubmissionDetails({ submissionId, onBack }) {
+  const router = useRouter();
+  const [loading, setLoading] = useState(true);
+  const [submission, setSubmission] = useState(null);
+  const [detailInfo, setDetailInfo] = useState({ type: "fund_application", data: null });
+  const [submissionUsers, setSubmissionUsers] = useState([]);
+  const [attachments, setAttachments] = useState([]);
+  const [attachmentsLoading, setAttachmentsLoading] = useState(false);
+  const [creatingMerged, setCreatingMerged] = useState(false);
+  const [merging, setMerging] = useState(false);
+  const [error, setError] = useState(null);
+  const mergedUrlRef = useRef(null);
+
+  const cleanupMerged = () => {
+    if (mergedUrlRef.current) {
+      URL.revokeObjectURL(mergedUrlRef.current);
+      mergedUrlRef.current = null;
+    }
+  };
+
+  useEffect(() => {
+    return () => cleanupMerged();
+  }, []);
+
+  const loadDetails = async () => {
+    if (!submissionId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await deptHeadSubmissionAPI.getSubmissionDetails(submissionId);
+      const baseSubmission = response?.submission || response;
+      const detail = normalizeDetail(baseSubmission, response);
+      const users = response?.submission_users || baseSubmission?.submission_users || [];
+      setSubmission(baseSubmission);
+      setDetailInfo(detail);
+      setSubmissionUsers(users);
+
+      setAttachmentsLoading(true);
+      try {
+        const [documentRes, typeRes] = await Promise.all([
+          deptHeadSubmissionAPI.getSubmissionDocuments(baseSubmission.submission_id || submissionId),
+          deptHeadSubmissionAPI.getDocumentTypes(),
+        ]);
+        const documents =
+          documentRes?.documents || documentRes?.data || documentRes || baseSubmission?.documents || [];
+        const types = typeRes?.document_types || typeRes?.data || typeRes || [];
+        setAttachments(mapDocumentTypeNames(documents, types));
+      } catch (docError) {
+        console.error("Failed to load documents", docError);
+        setAttachments([]);
+      } finally {
+        setAttachmentsLoading(false);
+      }
+    } catch (fetchError) {
+      console.error("Failed to load submission details", fetchError);
+      setError(fetchError?.message || "ไม่สามารถโหลดข้อมูลคำร้องได้");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    loadDetails();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [submissionId]);
+
+  const handleViewDocument = async (fileId) => {
+    if (!fileId) return;
+    try {
+      const token = apiClient.getToken();
+      const url = `${apiClient.baseURL}/files/managed/${fileId}/download`;
+      const response = await fetch(url, {
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+      });
+      if (!response.ok) throw new Error("File not found");
+      const blob = await response.blob();
+      const fileUrl = window.URL.createObjectURL(blob);
+      window.open(fileUrl, "_blank");
+      window.URL.revokeObjectURL(fileUrl);
+    } catch (docError) {
+      console.error("Failed to open document", docError);
+      toast.error("ไม่สามารถเปิดไฟล์ได้");
+    }
+  };
+
+  const handleDownloadDocument = async (fileId, fileName = "document") => {
+    if (!fileId) return;
+    try {
+      await apiClient.downloadFile(`/files/managed/${fileId}/download`, fileName);
+    } catch (docError) {
+      console.error("Failed to download document", docError);
+      toast.error("ไม่สามารถดาวน์โหลดไฟล์ได้");
+    }
+  };
+
+  const fetchFileAsBlob = async (fileId) => {
+    const token = apiClient.getToken();
+    const url = `${apiClient.baseURL}/files/managed/${fileId}/download`;
+    const response = await fetch(url, {
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+    });
+    if (!response.ok) throw new Error("File not found");
+    return await response.blob();
+  };
+
+  const mergeAttachmentsToPdf = async (docs) => {
+    setMerging(true);
+    try {
+      const merged = await PDFDocument.create();
+      for (const doc of docs) {
+        try {
+          const blob = await fetchFileAsBlob(doc.file_id);
+          const pdf = await PDFDocument.load(await blob.arrayBuffer(), {
+            ignoreEncryption: true,
+          });
+          const pages = await merged.copyPages(pdf, pdf.getPageIndices());
+          pages.forEach((page) => merged.addPage(page));
+        } catch (docError) {
+          console.warn("Skip non-pdf", docError);
+        }
+      }
+      if (merged.getPageCount() === 0) {
+        throw new Error("ไม่มีไฟล์ PDF สำหรับรวม");
+      }
+      const bytes = await merged.save();
+      return new Blob([bytes], { type: "application/pdf" });
+    } finally {
+      setMerging(false);
+    }
+  };
+
+  const ensureMergedUrl = async () => {
+    if (mergedUrlRef.current) {
+      return mergedUrlRef.current;
+    }
+    setCreatingMerged(true);
+    try {
+      const pdfLike = attachments.filter((doc) =>
+        String(doc.original_name || "").toLowerCase().endsWith(".pdf")
+      );
+      const candidate = pdfLike.length ? pdfLike : attachments;
+      if (!candidate.length) {
+        toast.error("ไม่มีไฟล์สำหรับรวม");
+        return null;
+      }
+      const blob = await mergeAttachmentsToPdf(candidate);
+      const url = URL.createObjectURL(blob);
+      mergedUrlRef.current = url;
+      return url;
+    } catch (mergeError) {
+      console.error("Failed to merge documents", mergeError);
+      toast.error(mergeError?.message || "ไม่สามารถรวมไฟล์ได้");
+      return null;
+    } finally {
+      setCreatingMerged(false);
+    }
+  };
+
+  const handleViewMerged = async () => {
+    const url = await ensureMergedUrl();
+    if (url) {
+      window.open(url, "_blank");
+    }
+  };
+
+  const handleDownloadMerged = async () => {
+    const url = await ensureMergedUrl();
+    if (!url) return;
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = `submission_${submission?.submission_number || submissionId}_attachments.pdf`;
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+  };
+
+  const navigateBackToList = () => {
+    if (onBack) {
+      onBack();
+    } else {
+      router.push("/member/dept-review");
+    }
+    router.refresh();
+  };
+
+  const handleRecommend = async () => {
+    if (!submission) return;
+    const { value: comment } = await Swal.fire({
+      title: "ความคิดเห็นเพิ่มเติม (ถ้ามี)",
+      input: "textarea",
+      inputPlaceholder: "ระบุเหตุผลหรือความคิดเห็นเพิ่มเติม",
+      showCancelButton: true,
+      confirmButtonText: "ยืนยันเห็นควร",
+      cancelButtonText: "ยกเลิก",
+      inputValidator: () => null,
+    });
+
+    if (comment === undefined) {
+      return;
+    }
+
+    try {
+      await deptHeadSubmissionAPI.recommendSubmission(submission.submission_id, {
+        comment: comment?.trim() ? comment.trim() : undefined,
+      });
+      toast.success("ส่งต่อคำร้องไปยังผู้ดูแลระบบแล้ว");
+      navigateBackToList();
+    } catch (actionError) {
+      console.error("Failed to recommend submission", actionError);
+      toast.error(actionError?.message || "ไม่สามารถบันทึกผลการพิจารณาได้");
+    }
+  };
+
+  const handleReject = async () => {
+    if (!submission) return;
+    const { value: reason } = await Swal.fire({
+      title: "ระบุเหตุผลการไม่เห็นควร",
+      input: "textarea",
+      inputPlaceholder: "กรอกเหตุผลการไม่เห็นควรพิจารณา",
+      showCancelButton: true,
+      confirmButtonText: "ยืนยันไม่เห็นควร",
+      cancelButtonText: "ยกเลิก",
+      inputValidator: (value) => {
+        if (!value || !value.trim()) {
+          return "กรุณาระบุเหตุผล";
+        }
+        return null;
+      },
+    });
+
+    if (reason === undefined) {
+      return;
+    }
+
+    try {
+      await deptHeadSubmissionAPI.rejectSubmission(submission.submission_id, {
+        rejection_reason: reason.trim(),
+        comment: reason.trim(),
+      });
+      toast.success("บันทึกผลการไม่เห็นควรแล้ว");
+      navigateBackToList();
+    } catch (actionError) {
+      console.error("Failed to reject submission", actionError);
+      toast.error(actionError?.message || "ไม่สามารถบันทึกผลการพิจารณาได้");
+    }
+  };
+
+  if (loading) {
+    return (
+      <PageLayout
+        title="รายละเอียดคำร้อง"
+        subtitle="กำลังโหลดข้อมูลคำร้อง"
+        icon={FileText}
+      >
+        <div className="flex flex-col items-center justify-center py-24 text-gray-500">
+          <Loader2 className="animate-spin mb-4" size={32} />
+          กำลังโหลดข้อมูล...
+        </div>
+      </PageLayout>
+    );
+  }
+
+  if (error) {
+    return (
+      <PageLayout
+        title="รายละเอียดคำร้อง"
+        subtitle="ไม่สามารถโหลดข้อมูลได้"
+        icon={FileText}
+        actions={
+          <button
+            onClick={() => router.back()}
+            className="inline-flex items-center gap-2 px-4 py-2 text-sm border border-gray-200 rounded-md text-gray-700 hover:bg-gray-50"
+          >
+            <ArrowLeft size={16} /> กลับ
+          </button>
+        }
+      >
+        <div className="text-center text-red-600 py-16">{error}</div>
+      </PageLayout>
+    );
+  }
+
+  if (!submission) {
+    return null;
+  }
+
+  const applicant = getApplicant(submission);
+  const comment = submission.comment || submission.Comment || "";
+  const statusLabel = submission.status?.status_name || submission.status_name;
+  const statusId = submission.status_id;
+  const submittedAt =
+    submission.submitted_at || submission.SubmittedAt || submission.created_at;
+
+  const metaItems = [
+    {
+      label: "ปีงบประมาณ",
+      value:
+        submission.year?.year ||
+        submission.year_th ||
+        submission.year?.Year ||
+        submission.year,
+    },
+    {
+      label: "หมวดทุน",
+      value:
+        submission.category?.category_name ||
+        submission.category_name ||
+        submission.Category?.category_name,
+    },
+    {
+      label: "ทุนย่อย",
+      value:
+        submission.subcategory?.subcategory_name ||
+        submission.subcategory_name ||
+        submission.Subcategory?.subcategory_name,
+    },
+  ].filter((item) => item.value);
+
+  const detailContent =
+    detailInfo.type === "publication_reward" ? (
+      <PublicationRewardSection detail={detailInfo.data} />
+    ) : (
+      <FundApplicationSection submission={submission} detail={detailInfo.data} />
+    );
+
+  return (
+    <PageLayout
+      title={`รายละเอียดคำร้อง ${submission.submission_number || ""}`.trim()}
+      subtitle="ตรวจสอบรายละเอียดและดำเนินการในฐานะหัวหน้าสาขา"
+      icon={FileText}
+      actions={
+        <button
+          onClick={() => router.back()}
+          className="inline-flex items-center gap-2 px-4 py-2 text-sm border border-gray-200 rounded-md text-gray-700 hover:bg-gray-50"
+        >
+          <ArrowLeft size={16} /> กลับ
+        </button>
+      }
+    >
+      <Card collapsible={false}>
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          <div className="lg:col-span-2 space-y-4">
+            <div className="flex flex-wrap items-center gap-3">
+              <StatusBadge statusId={statusId} fallbackLabel={statusLabel} />
+              <span className="text-sm text-gray-500">
+                ยื่นเมื่อ {formatDateTime(submittedAt)}
+              </span>
+            </div>
+            <div>
+              <p className="text-gray-500 text-sm">ผู้ยื่นคำร้อง</p>
+              <p className="text-lg font-semibold text-gray-900">
+                {getUserFullName(applicant)}
+              </p>
+              {applicant?.email ? (
+                <p className="text-sm text-gray-500">{applicant.email}</p>
+              ) : null}
+            </div>
+            {comment ? (
+              <div>
+                <p className="text-gray-500 text-sm mb-1">หมายเหตุจากคำร้อง</p>
+                <p className="bg-gray-50 border border-gray-100 rounded-lg p-3 text-gray-700 whitespace-pre-wrap">
+                  {comment}
+                </p>
+              </div>
+            ) : null}
+          </div>
+          <div className="space-y-3">
+            {metaItems.map((item) => (
+              <div key={item.label} className="bg-gray-50 rounded-lg px-4 py-3">
+                <p className="text-xs text-gray-500 uppercase tracking-wide">
+                  {item.label}
+                </p>
+                <p className="text-sm font-semibold text-gray-900">{item.value}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </Card>
+
+      <div className="mt-6 space-y-6">
+        {detailContent}
+        <SubmissionTeamCard submissionUsers={submissionUsers} />
+        <AttachmentsCard
+          submission={submission}
+          attachments={attachments}
+          onView={handleViewDocument}
+          onDownload={handleDownloadDocument}
+          onViewMerged={handleViewMerged}
+          onDownloadMerged={handleDownloadMerged}
+          loading={attachmentsLoading}
+          merging={merging}
+          creatingMerged={creatingMerged}
+        />
+        <ActionPanel
+          onRecommend={handleRecommend}
+          onReject={handleReject}
+          disabled={creatingMerged || merging}
+        />
+      </div>
+    </PageLayout>
+  );
+}

--- a/frontend_project_fund/app/member/dept-review/[submissionId]/page.js
+++ b/frontend_project_fund/app/member/dept-review/[submissionId]/page.js
@@ -1,0 +1,20 @@
+"use client";
+
+import { useParams, useRouter } from "next/navigation";
+import AuthGuard from "@/app/components/AuthGuard";
+import DeptHeadSubmissionDetails from "@/app/member/components/dept/details/DeptHeadSubmissionDetails";
+
+export default function DeptHeadSubmissionDetailsPage() {
+  const params = useParams();
+  const router = useRouter();
+  const submissionId = params?.submissionId;
+
+  return (
+    <AuthGuard allowedRoles={[4, "dept_head"]} requireAuth>
+      <DeptHeadSubmissionDetails
+        submissionId={submissionId}
+        onBack={() => router.push("/member/dept-review")}
+      />
+    </AuthGuard>
+  );
+}

--- a/frontend_project_fund/app/member/dept-review/page.js
+++ b/frontend_project_fund/app/member/dept-review/page.js
@@ -1,6 +1,6 @@
 "use client";
 
-import AuthGuard from "../../components/AuthGuard";
+import AuthGuard from "@/app/components/AuthGuard";
 import DeptHeadReview from "../components/dept/DeptHeadReview";
 
 export default function DeptReviewPage() {

--- a/fund-management-api/controllers/dept_head_submission.go
+++ b/fund-management-api/controllers/dept_head_submission.go
@@ -1,0 +1,523 @@
+package controllers
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"fund-management-api/config"
+	"fund-management-api/models"
+	"fund-management-api/utils"
+
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+)
+
+func GetDeptHeadSubmissions(c *gin.Context) {
+	statusCode := c.DefaultQuery("status_code", utils.StatusCodeDeptHeadPending)
+
+	status, err := utils.GetApplicationStatusByCode(statusCode)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{
+			"success": false,
+			"error":   err.Error(),
+		})
+		return
+	}
+
+	var submissions []models.Submission
+	query := config.DB.Preload("Status").
+		Preload("User").
+		Preload("Category").
+		Preload("Subcategory").
+		Preload("SubmissionUsers.User").
+		Where("submissions.deleted_at IS NULL").
+		Where("submissions.status_id = ?", status.ApplicationStatusID)
+
+	if err := query.Order("COALESCE(submissions.submitted_at, submissions.created_at) DESC").Find(&submissions).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"success": false,
+			"error":   "Failed to fetch submissions",
+		})
+		return
+	}
+
+	responseItems := make([]gin.H, 0, len(submissions))
+	for _, submission := range submissions {
+		applicantUser := extractApplicantUser(&submission)
+		applicantName := formatUserFullName(applicantUser)
+		applicantPayload := gin.H{}
+		if applicantUser != nil {
+			applicantPayload = gin.H{
+				"user_id":    applicantUser.UserID,
+				"user_fname": applicantUser.UserFname,
+				"user_lname": applicantUser.UserLname,
+				"email":      applicantUser.Email,
+			}
+		}
+		responseItems = append(responseItems, gin.H{
+			"submission_id":     submission.SubmissionID,
+			"submission_number": submission.SubmissionNumber,
+			"submission_type":   submission.SubmissionType,
+			"status_id":         submission.StatusID,
+			"status": gin.H{
+				"application_status_id": submission.Status.ApplicationStatusID,
+				"status_code":           submission.Status.StatusCode,
+				"status_name":           submission.Status.StatusName,
+			},
+			"category_id":      submission.CategoryID,
+			"category_name":    submission.CategoryName,
+			"subcategory_id":   submission.SubcategoryID,
+			"subcategory_name": submission.SubcategoryName,
+			"submitted_at":     submission.SubmittedAt,
+			"created_at":       submission.CreatedAt,
+			"applicant":        applicantPayload,
+			"applicant_name":   applicantName,
+			"user":             submission.User,
+		})
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"success": true,
+		"filters": gin.H{
+			"status_code": statusCode,
+			"status": gin.H{
+				"application_status_id": status.ApplicationStatusID,
+				"status_code":           status.StatusCode,
+				"status_name":           status.StatusName,
+			},
+		},
+		"submissions": responseItems,
+	})
+}
+
+func GetDeptHeadSubmissionDetails(c *gin.Context) {
+	submissionIDStr := c.Param("id")
+	submissionID, err := strconv.Atoi(submissionIDStr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid submission ID"})
+		return
+	}
+
+	payload, err := buildSubmissionDetailPayload(submissionID)
+	if err != nil {
+		status := http.StatusInternalServerError
+		if err == gorm.ErrRecordNotFound {
+			status = http.StatusNotFound
+		}
+		c.JSON(status, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, payload)
+}
+
+func DeptHeadRecommendSubmission(c *gin.Context) {
+	submissionIDStr := c.Param("id")
+	submissionID, err := strconv.Atoi(submissionIDStr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid submission ID"})
+		return
+	}
+
+	var req struct {
+		Comment string `json:"comment"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil && !strings.Contains(err.Error(), "EOF") {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request payload"})
+		return
+	}
+
+	userIDVal, _ := c.Get("userID")
+	userID := userIDVal.(int)
+
+	tx := config.DB.Begin()
+	if tx.Error != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to start transaction"})
+		return
+	}
+
+	var submission models.Submission
+	if err := tx.Preload("Status").First(&submission, submissionID).Error; err != nil {
+		tx.Rollback()
+		if err == gorm.ErrRecordNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Submission not found"})
+		} else {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to load submission"})
+		}
+		return
+	}
+
+	allowed, err := utils.StatusMatchesCodes(submission.StatusID, utils.StatusCodeDeptHeadPending)
+	if err != nil {
+		tx.Rollback()
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to verify submission status"})
+		return
+	}
+	if !allowed {
+		tx.Rollback()
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Submission is not awaiting department review"})
+		return
+	}
+
+	targetStatus, err := utils.GetApplicationStatusByCode(utils.StatusCodePending)
+	if err != nil {
+		tx.Rollback()
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to resolve target status"})
+		return
+	}
+
+	now := time.Now()
+	updates := map[string]interface{}{
+		"status_id":        targetStatus.ApplicationStatusID,
+		"updated_at":       now,
+		"reviewed_at":      now,
+		"head_approved_at": now,
+		"head_approved_by": userID,
+	}
+
+	comment := strings.TrimSpace(req.Comment)
+	if comment != "" {
+		updates["comment"] = comment
+	} else {
+		updates["comment"] = gorm.Expr("NULL")
+	}
+
+	if err := tx.Model(&models.Submission{}).
+		Where("submission_id = ?", submissionID).
+		Updates(updates).Error; err != nil {
+		tx.Rollback()
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update submission"})
+		return
+	}
+
+	logDescription := comment
+	if logDescription == "" {
+		logDescription = "Department head recommended submission"
+	}
+	auditLog := models.AuditLog{
+		UserID:       userID,
+		Action:       "review",
+		EntityType:   "submission",
+		EntityID:     &submission.SubmissionID,
+		EntityNumber: &submission.SubmissionNumber,
+		Description:  &logDescription,
+		IPAddress:    c.ClientIP(),
+		CreatedAt:    now,
+	}
+	if err := tx.Create(&auditLog).Error; err != nil {
+		tx.Rollback()
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to record audit log"})
+		return
+	}
+
+	if err := tx.Commit().Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save recommendation"})
+		return
+	}
+
+	payload, err := buildSubmissionDetailPayload(submissionID)
+	if err != nil {
+		c.JSON(http.StatusOK, gin.H{"success": true})
+		return
+	}
+
+	payload["success"] = true
+	c.JSON(http.StatusOK, payload)
+}
+
+func DeptHeadRejectSubmission(c *gin.Context) {
+	submissionIDStr := c.Param("id")
+	submissionID, err := strconv.Atoi(submissionIDStr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid submission ID"})
+		return
+	}
+
+	var req struct {
+		RejectionReason string `json:"rejection_reason" binding:"required"`
+		Comment         string `json:"comment"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Rejection reason is required"})
+		return
+	}
+
+	reason := strings.TrimSpace(req.RejectionReason)
+	if reason == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Rejection reason is required"})
+		return
+	}
+	comment := strings.TrimSpace(req.Comment)
+	if comment == "" {
+		comment = reason
+	}
+
+	userIDVal, _ := c.Get("userID")
+	userID := userIDVal.(int)
+
+	tx := config.DB.Begin()
+	if tx.Error != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to start transaction"})
+		return
+	}
+
+	var submission models.Submission
+	if err := tx.Preload("Status").First(&submission, submissionID).Error; err != nil {
+		tx.Rollback()
+		if err == gorm.ErrRecordNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "Submission not found"})
+		} else {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to load submission"})
+		}
+		return
+	}
+
+	allowed, err := utils.StatusMatchesCodes(submission.StatusID, utils.StatusCodeDeptHeadPending)
+	if err != nil {
+		tx.Rollback()
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to verify submission status"})
+		return
+	}
+	if !allowed {
+		tx.Rollback()
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Submission is not awaiting department review"})
+		return
+	}
+
+	rejectStatus, err := utils.GetApplicationStatusByCode(utils.StatusCodeRejected)
+	if err != nil {
+		tx.Rollback()
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to resolve rejection status"})
+		return
+	}
+
+	now := time.Now()
+	updates := map[string]interface{}{
+		"status_id":        rejectStatus.ApplicationStatusID,
+		"updated_at":       now,
+		"reviewed_at":      now,
+		"head_approved_at": now,
+		"head_approved_by": userID,
+		"closed_at":        now,
+		"comment":          comment,
+	}
+
+	if err := tx.Model(&models.Submission{}).
+		Where("submission_id = ?", submissionID).
+		Updates(updates).Error; err != nil {
+		tx.Rollback()
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update submission"})
+		return
+	}
+
+	switch submission.SubmissionType {
+	case "publication_reward":
+		detailUpdates := map[string]interface{}{
+			"rejection_reason": reason,
+			"rejected_by":      userID,
+			"rejected_at":      now,
+			"update_at":        now,
+		}
+		if err := tx.Model(&models.PublicationRewardDetail{}).
+			Where("submission_id = ?", submissionID).
+			Updates(detailUpdates).Error; err != nil {
+			tx.Rollback()
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to record rejection details"})
+			return
+		}
+	case "fund_application":
+		detailUpdates := map[string]interface{}{
+			"comment":     comment,
+			"rejected_by": userID,
+			"rejected_at": now,
+			"closed_at":   now,
+		}
+		if err := tx.Model(&models.FundApplicationDetail{}).
+			Where("submission_id = ?", submissionID).
+			Updates(detailUpdates).Error; err != nil {
+			tx.Rollback()
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to record rejection details"})
+			return
+		}
+	}
+
+	desc := reason
+	auditLog := models.AuditLog{
+		UserID:       userID,
+		Action:       "reject",
+		EntityType:   "submission",
+		EntityID:     &submission.SubmissionID,
+		EntityNumber: &submission.SubmissionNumber,
+		Description:  &desc,
+		IPAddress:    c.ClientIP(),
+		CreatedAt:    now,
+	}
+	if err := tx.Create(&auditLog).Error; err != nil {
+		tx.Rollback()
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to record audit log"})
+		return
+	}
+
+	if err := tx.Commit().Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save rejection"})
+		return
+	}
+
+	payload, err := buildSubmissionDetailPayload(submissionID)
+	if err != nil {
+		c.JSON(http.StatusOK, gin.H{"success": true})
+		return
+	}
+
+	payload["success"] = true
+	c.JSON(http.StatusOK, payload)
+}
+
+func buildSubmissionDetailPayload(submissionID int) (gin.H, error) {
+	var submission models.Submission
+	query := config.DB.Preload("User").
+		Preload("Year").
+		Preload("Status").
+		Preload("FundApplicationDetail.Subcategory.Category").
+		Preload("PublicationRewardDetail")
+
+	if err := query.First(&submission, submissionID).Error; err != nil {
+		return nil, err
+	}
+
+	var submissionUsers []models.SubmissionUser
+	if err := config.DB.Where("submission_id = ?", submissionID).
+		Preload("User").
+		Order("display_order ASC").
+		Find(&submissionUsers).Error; err != nil {
+		submissionUsers = []models.SubmissionUser{}
+	}
+
+	var documents []models.SubmissionDocument
+	config.DB.Where("submission_id = ?", submissionID).
+		Preload("DocumentType").
+		Preload("File").
+		Find(&documents)
+
+	response := gin.H{
+		"submission": gin.H{
+			"submission_id":         submission.SubmissionID,
+			"submission_number":     submission.SubmissionNumber,
+			"submission_type":       submission.SubmissionType,
+			"user_id":               submission.UserID,
+			"year_id":               submission.YearID,
+			"category_id":           submission.CategoryID,
+			"subcategory_id":        submission.SubcategoryID,
+			"subcategory_budget_id": submission.SubcategoryBudgetID,
+			"status_id":             submission.StatusID,
+			"submitted_at":          submission.SubmittedAt,
+			"created_at":            submission.CreatedAt,
+			"updated_at":            submission.UpdatedAt,
+			"user":                  submission.User,
+			"year":                  submission.Year,
+			"status":                submission.Status,
+			"comment":               submission.Comment,
+		},
+		"details":          nil,
+		"submission_users": []gin.H{},
+		"documents":        []gin.H{},
+	}
+
+	if submission.SubmissionType == "publication_reward" && submission.PublicationRewardDetail != nil {
+		response["details"] = gin.H{
+			"type": "publication_reward",
+			"data": submission.PublicationRewardDetail,
+		}
+	} else if submission.SubmissionType == "fund_application" && submission.FundApplicationDetail != nil {
+		response["details"] = gin.H{
+			"type": "fund_application",
+			"data": submission.FundApplicationDetail,
+		}
+	}
+
+	for _, su := range submissionUsers {
+		if su.User == nil {
+			var user models.User
+			if err := config.DB.Where("user_id = ?", su.UserID).First(&user).Error; err == nil {
+				su.User = &user
+			} else {
+				continue
+			}
+		}
+		response["submission_users"] = append(response["submission_users"].([]gin.H), gin.H{
+			"user_id":       su.UserID,
+			"role":          su.Role,
+			"display_order": su.DisplayOrder,
+			"is_primary":    su.IsPrimary,
+			"created_at":    su.CreatedAt,
+			"user": gin.H{
+				"user_id":    su.User.UserID,
+				"user_fname": su.User.UserFname,
+				"user_lname": su.User.UserLname,
+				"email":      su.User.Email,
+			},
+		})
+	}
+
+	for _, doc := range documents {
+		docInfo := gin.H{
+			"document_id":      doc.DocumentID,
+			"submission_id":    doc.SubmissionID,
+			"file_id":          doc.FileID,
+			"document_type_id": doc.DocumentTypeID,
+			"description":      doc.Description,
+			"display_order":    doc.DisplayOrder,
+			"is_required":      doc.IsRequired,
+			"created_at":       doc.CreatedAt,
+		}
+		if doc.DocumentType.DocumentTypeID != 0 {
+			docInfo["document_type"] = gin.H{
+				"document_type_id":   doc.DocumentType.DocumentTypeID,
+				"document_type_name": doc.DocumentType.DocumentTypeName,
+			}
+		}
+		if doc.File.FileID != 0 {
+			docInfo["file"] = gin.H{
+				"file_id":       doc.File.FileID,
+				"original_name": doc.File.OriginalName,
+				"file_size":     doc.File.FileSize,
+				"mime_type":     doc.File.MimeType,
+				"uploaded_at":   doc.File.UploadedAt,
+			}
+		}
+		response["documents"] = append(response["documents"].([]gin.H), docInfo)
+	}
+
+	return response, nil
+}
+
+func extractApplicantUser(submission *models.Submission) *models.User {
+	if submission.User != nil {
+		return submission.User
+	}
+
+	for _, su := range submission.SubmissionUsers {
+		if su.IsPrimary || strings.EqualFold(su.Role, "owner") {
+			if su.User != nil {
+				return su.User
+			}
+		}
+	}
+
+	return nil
+}
+
+func formatUserFullName(user *models.User) string {
+	if user == nil {
+		return ""
+	}
+	first := strings.TrimSpace(user.UserFname)
+	last := strings.TrimSpace(user.UserLname)
+	full := strings.TrimSpace(strings.TrimSpace(first + " " + last))
+	if full != "" {
+		return full
+	}
+	return strings.TrimSpace(user.Email)
+}

--- a/fund-management-api/routes/routes.go
+++ b/fund-management-api/routes/routes.go
@@ -156,6 +156,16 @@ func SetupRoutes(router *gin.Engine) {
 				staff.GET("/dashboard/stats", controllers.GetDashboardStats)
 			}
 
+			// Dept head review endpoints
+			deptHead := protected.Group("/dept-head")
+			deptHead.Use(middleware.RequireRole(4))
+			{
+				deptHead.GET("/submissions", controllers.GetDeptHeadSubmissions)
+				deptHead.GET("/submissions/:id/details", controllers.GetDeptHeadSubmissionDetails)
+				deptHead.POST("/submissions/:id/recommend", controllers.DeptHeadRecommendSubmission)
+				deptHead.POST("/submissions/:id/reject", controllers.DeptHeadRejectSubmission)
+			}
+
 			// Fund Applications
 			applications := protected.Group("/applications")
 			{


### PR DESCRIPTION
## Summary
- implement a dedicated department head submission controller to list, inspect, recommend, or reject submissions and register the new protected routes
- add a dept head client module and refresh the review table to consume the scoped API and open submission details
- create the dept head submission detail page with full read-only data, document utilities, and recommend/reject actions

## Testing
- ⚠️ `go test ./...` *(hangs without producing output, cancelled)*
- ⚠️ `npm run lint` *(requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d56a81fa08832289a22ebdf86f662d