### PR TITLE
Implement publication reward preview flow

### DIFF
--- a/fund-management-api/controllers/publication_reward_preview.go
+++ b/fund-management-api/controllers/publication_reward_preview.go
@@ -2,32 +2,108 @@ package controllers
 
 import (
 	"archive/zip"
+	"bytes"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"fund-management-api/config"
 	"fund-management-api/models"
 	"fund-management-api/utils"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"gorm.io/gorm"
 )
 
-// PublicationRewardPreviewRequest represents the payload for generating a preview PDF.
-type PublicationRewardPreviewRequest struct {
+// PublicationRewardPreviewSubmissionRequest represents the payload for generating a preview from a stored submission.
+type PublicationRewardPreviewSubmissionRequest struct {
 	SubmissionID int `json:"submission_id" binding:"required"`
+}
+
+// PublicationRewardPreviewFormPayload represents the form-based preview payload.
+type PublicationRewardPreviewFormPayload struct {
+	FormData    PublicationRewardPreviewFormData     `json:"formData"`
+	Applicant   PublicationRewardPreviewApplicant    `json:"applicant"`
+	Coauthors   []PublicationRewardPreviewCoauthor   `json:"coauthors"`
+	Attachments []PublicationRewardPreviewAttachment `json:"attachments"`
+	External    []PublicationRewardPreviewExternal   `json:"external_fundings"`
+}
+
+type PublicationRewardPreviewFormData struct {
+	AuthorStatus          string `json:"author_status"`
+	ArticleTitle          string `json:"article_title"`
+	JournalName           string `json:"journal_name"`
+	JournalIssue          string `json:"journal_issue"`
+	JournalPages          string `json:"journal_pages"`
+	JournalMonth          string `json:"journal_month"`
+	JournalYear           string `json:"journal_year"`
+	JournalQuartile       string `json:"journal_quartile"`
+	PublicationReward     string `json:"publication_reward"`
+	RevisionFee           string `json:"revision_fee"`
+	PublicationFee        string `json:"publication_fee"`
+	ExternalFundingAmount string `json:"external_funding_amount"`
+	TotalAmount           string `json:"total_amount"`
+	AuthorNameList        string `json:"author_name_list"`
+	Signature             string `json:"signature"`
+	PublicationDate       string `json:"publication_date"`
+	Doi                   string `json:"doi"`
+	VolumeIssue           string `json:"volume_issue"`
+	PageNumbers           string `json:"page_numbers"`
+	JournalURL            string `json:"journal_url"`
+	ArticleOnlineDB       string `json:"article_online_db"`
+	ArticleOnlineDate     string `json:"article_online_date"`
+}
+
+type PublicationRewardPreviewApplicant struct {
+	PrefixName       string `json:"prefix_name"`
+	FirstName        string `json:"user_fname"`
+	LastName         string `json:"user_lname"`
+	PositionName     string `json:"position_name"`
+	DateOfEmployment string `json:"date_of_employment"`
+}
+
+type PublicationRewardPreviewCoauthor struct {
+	Order  int    `json:"order"`
+	UserID int    `json:"user_id"`
+	First  string `json:"user_fname"`
+	Last   string `json:"user_lname"`
+}
+
+type PublicationRewardPreviewAttachment struct {
+	Filename         string `json:"filename"`
+	DocumentTypeID   *int   `json:"document_type_id"`
+	DocumentTypeName string `json:"document_type_name"`
+	DisplayOrder     int    `json:"display_order"`
+}
+
+type PublicationRewardPreviewExternal struct {
+	FundName string `json:"fund_name"`
+	Amount   string `json:"amount"`
 }
 
 // PreviewPublicationReward generates a Publication Reward preview PDF from a DOCX template.
 func PreviewPublicationReward(c *gin.Context) {
-	var req PublicationRewardPreviewRequest
+	contentType := c.GetHeader("Content-Type")
+	if strings.HasPrefix(contentType, "multipart/form-data") {
+		handlePublicationRewardPreviewForm(c)
+		return
+	}
+
+	handlePublicationRewardPreviewSubmission(c)
+}
+
+func handlePublicationRewardPreviewSubmission(c *gin.Context) {
+	var req PublicationRewardPreviewSubmissionRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request payload"})
 		return
@@ -106,6 +182,342 @@ func PreviewPublicationReward(c *gin.Context) {
 	c.Header("Content-Type", "application/pdf")
 	c.Header("Content-Disposition", "inline; filename=publication_reward_preview.pdf")
 	c.Data(http.StatusOK, "application/pdf", pdfData)
+}
+
+func handlePublicationRewardPreviewForm(c *gin.Context) {
+	if err := c.Request.ParseMultipartForm(64 << 20); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "failed to parse form data"})
+		return
+	}
+	defer c.Request.MultipartForm.RemoveAll()
+
+	form := c.Request.MultipartForm
+	rawPayload := form.Value["data"]
+	if len(rawPayload) == 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "missing form payload"})
+		return
+	}
+
+	var payload PublicationRewardPreviewFormPayload
+	decoder := json.NewDecoder(strings.NewReader(rawPayload[0]))
+	decoder.UseNumber()
+	if err := decoder.Decode(&payload); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid form payload"})
+		return
+	}
+
+	sysConfig, err := fetchLatestSystemConfig()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load system configuration"})
+		return
+	}
+
+	attachments := form.File["attachments"]
+
+	replacements, err := buildFormPreviewReplacements(&payload, sysConfig, attachments)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	pdfData, err := generatePublicationRewardPDF(replacements)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	merged, err := mergePreviewPDFWithAttachments(pdfData, attachments)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.Header("Content-Type", "application/pdf")
+	c.Header("Content-Disposition", "inline; filename=publication_reward_preview.pdf")
+	c.Data(http.StatusOK, "application/pdf", merged)
+}
+
+func buildFormPreviewReplacements(payload *PublicationRewardPreviewFormPayload, sysConfig *systemConfigSnapshot, attachments []*multipart.FileHeader) (map[string]string, error) {
+	if payload == nil {
+		return nil, fmt.Errorf("invalid form payload")
+	}
+
+	if sysConfig == nil {
+		sysConfig = &systemConfigSnapshot{}
+	}
+
+	totalAmount := parseFormFloat(payload.FormData.TotalAmount)
+	publicationDate := resolveFormPublicationDate(&payload.FormData)
+	publicationDateText := ""
+	if publicationDate != nil {
+		publicationDateText = utils.FormatThaiDate(*publicationDate)
+	}
+
+	replacements := map[string]string{
+		"{{date_th}}":            utils.FormatThaiDate(time.Now()),
+		"{{applicant_name}}":     buildPreviewApplicantName(payload.Applicant),
+		"{{date_of_employment}}": formatThaiDateFromString(payload.Applicant.DateOfEmployment),
+		"{{position}}":           strings.TrimSpace(payload.Applicant.PositionName),
+		"{{installment}}":        formatNullableInt(sysConfig.Installment),
+		"{{total_amount}}":       formatAmount(totalAmount),
+		"{{total_amount_text}}":  utils.BahtText(totalAmount),
+		"{{author_name_list}}":   strings.TrimSpace(payload.FormData.AuthorNameList),
+		"{{paper_title}}":        strings.TrimSpace(payload.FormData.ArticleTitle),
+		"{{journal_name}}":       strings.TrimSpace(payload.FormData.JournalName),
+		"{{publication_date}}":   publicationDateText,
+		"{{volume_issue}}":       strings.TrimSpace(payload.FormData.JournalIssue),
+		"{{page_numbers}}":       strings.TrimSpace(payload.FormData.JournalPages),
+		"{{author_role}}":        buildAuthorRole(payload.FormData.AuthorStatus),
+		"{{quartile_line}}":      buildQuartileLine(payload.FormData.JournalQuartile),
+		"{{document_line}}":      buildPreviewDocumentLine(payload.Attachments, attachments),
+		"{{kku_report_year}}":    formatNullableString(sysConfig.KkuReportYear),
+		"{{signature}}":          strings.TrimSpace(payload.FormData.Signature),
+	}
+
+	return replacements, nil
+}
+
+func parseFormFloat(raw string) float64 {
+	cleaned := strings.ReplaceAll(strings.TrimSpace(raw), ",", "")
+	if cleaned == "" {
+		return 0
+	}
+	value, err := strconv.ParseFloat(cleaned, 64)
+	if err != nil {
+		return 0
+	}
+	return value
+}
+
+func resolveFormPublicationDate(data *PublicationRewardPreviewFormData) *time.Time {
+	if data == nil {
+		return nil
+	}
+
+	raw := strings.TrimSpace(data.PublicationDate)
+	if raw != "" {
+		if t, err := time.Parse("2006-01-02", raw); err == nil {
+			return &t
+		}
+	}
+
+	year := strings.TrimSpace(data.JournalYear)
+	if year == "" {
+		return nil
+	}
+
+	month := strings.TrimSpace(data.JournalMonth)
+	monthValue, err := strconv.Atoi(month)
+	if err != nil || monthValue < 1 || monthValue > 12 {
+		monthValue = 1
+	}
+
+	dateStr := fmt.Sprintf("%s-%02d-01", year, monthValue)
+	if t, err := time.Parse("2006-01-02", dateStr); err == nil {
+		return &t
+	}
+
+	return nil
+}
+
+func formatThaiDateFromString(raw string) string {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return ""
+	}
+
+	if t, err := time.Parse("2006-01-02", trimmed); err == nil {
+		return utils.FormatThaiDate(t)
+	}
+
+	return ""
+}
+
+func buildPreviewApplicantName(app PublicationRewardPreviewApplicant) string {
+	parts := []string{
+		strings.TrimSpace(app.PrefixName),
+		strings.TrimSpace(app.FirstName),
+		strings.TrimSpace(app.LastName),
+	}
+	filtered := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part != "" {
+			filtered = append(filtered, part)
+		}
+	}
+	return strings.Join(filtered, " ")
+}
+
+func mergePreviewPDFWithAttachments(base []byte, files []*multipart.FileHeader) ([]byte, error) {
+	if len(files) == 0 {
+		return base, nil
+	}
+
+	tmpDir, err := os.MkdirTemp("", "publication-preview-merge-")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create temp directory: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	basePath := filepath.Join(tmpDir, "base.pdf")
+	if err := os.WriteFile(basePath, base, 0600); err != nil {
+		return nil, fmt.Errorf("failed to write base pdf: %w", err)
+	}
+
+	inputFiles := []string{basePath}
+
+	for idx, header := range files {
+		src, err := header.Open()
+		if err != nil {
+			return nil, fmt.Errorf("failed to open attachment %s: %w", header.Filename, err)
+		}
+		data, err := io.ReadAll(src)
+		src.Close()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read attachment %s: %w", header.Filename, err)
+		}
+		if len(bytes.TrimSpace(data)) == 0 {
+			continue
+		}
+		if !bytes.HasPrefix(data, []byte("%PDF")) {
+			return nil, fmt.Errorf("attachment %s is not a PDF file", header.Filename)
+		}
+
+		destPath := filepath.Join(tmpDir, fmt.Sprintf("attachment-%d.pdf", idx+1))
+		if err := os.WriteFile(destPath, data, 0600); err != nil {
+			return nil, fmt.Errorf("failed to write attachment %s: %w", header.Filename, err)
+		}
+		inputFiles = append(inputFiles, destPath)
+	}
+
+	if len(inputFiles) == 1 {
+		return base, nil
+	}
+
+	outputPath := filepath.Join(tmpDir, "merged.pdf")
+	if err := mergePDFsWithNode(inputFiles, outputPath); err != nil {
+		return nil, err
+	}
+
+	merged, err := os.ReadFile(outputPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read merged pdf: %w", err)
+	}
+
+	return merged, nil
+}
+
+func mergePDFsWithNode(inputs []string, outputPath string) error {
+	if len(inputs) == 0 {
+		return fmt.Errorf("no pdf files provided for merging")
+	}
+
+	scriptPath := filepath.Join("scripts", "merge_pdf.js")
+	absScriptPath, err := filepath.Abs(scriptPath)
+	if err != nil {
+		return fmt.Errorf("failed to resolve merge script path: %w", err)
+	}
+	if _, err := os.Stat(absScriptPath); err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("merge script not found at %s", absScriptPath)
+		}
+		return fmt.Errorf("failed to access merge script: %w", err)
+	}
+
+	nodeBinary, err := exec.LookPath("node")
+	if err != nil {
+		return fmt.Errorf("node binary not found: %w", err)
+	}
+
+	absOutput, err := filepath.Abs(outputPath)
+	if err != nil {
+		return fmt.Errorf("failed to resolve output path: %w", err)
+	}
+
+	absInputs := make([]string, 0, len(inputs))
+	for _, input := range inputs {
+		absInput, err := filepath.Abs(input)
+		if err != nil {
+			return fmt.Errorf("failed to resolve input path %s: %w", input, err)
+		}
+		absInputs = append(absInputs, absInput)
+	}
+
+	args := append([]string{absScriptPath, absOutput}, absInputs...)
+
+	repoDir := filepath.Dir(filepath.Dir(absScriptPath))
+	nodeModulesPath := filepath.Join(repoDir, "..", "frontend_project_fund", "node_modules")
+	absNodeModules, err := filepath.Abs(nodeModulesPath)
+	if err != nil {
+		return fmt.Errorf("failed to resolve node_modules path: %w", err)
+	}
+	if _, err := os.Stat(absNodeModules); err != nil {
+		return fmt.Errorf("pdf-lib dependency not found: %w", err)
+	}
+
+	cmd := exec.Command(nodeBinary, args...)
+	env := append([]string{}, os.Environ()...)
+	env = append(env, fmt.Sprintf("NODE_PATH=%s", absNodeModules))
+	cmd.Env = env
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = strings.TrimSpace(stdout.String())
+		}
+		if msg == "" {
+			msg = err.Error()
+		}
+		return fmt.Errorf("failed to merge pdf files: %s", msg)
+	}
+
+	return nil
+}
+
+func buildPreviewDocumentLine(meta []PublicationRewardPreviewAttachment, attachments []*multipart.FileHeader) string {
+	if len(meta) > 0 {
+		metaCopy := append([]PublicationRewardPreviewAttachment(nil), meta...)
+		sort.SliceStable(metaCopy, func(i, j int) bool {
+			if metaCopy[i].DisplayOrder == metaCopy[j].DisplayOrder {
+				return i < j
+			}
+			return metaCopy[i].DisplayOrder < metaCopy[j].DisplayOrder
+		})
+
+		lines := make([]string, 0, len(metaCopy))
+		for _, entry := range metaCopy {
+			name := strings.TrimSpace(entry.DocumentTypeName)
+			if name == "" {
+				name = strings.TrimSpace(entry.Filename)
+			}
+			if name == "" {
+				continue
+			}
+			lines = append(lines, "☑ "+name+" — จำนวน 1 ฉบับ")
+		}
+		if len(lines) > 0 {
+			return strings.Join(lines, "\n")
+		}
+	}
+
+	if len(attachments) == 0 {
+		return ""
+	}
+
+	lines := make([]string, 0, len(attachments))
+	for _, header := range attachments {
+		name := strings.TrimSpace(header.Filename)
+		if name == "" {
+			continue
+		}
+		lines = append(lines, "☑ "+name+" — จำนวน 1 ฉบับ")
+	}
+	return strings.Join(lines, "\n")
 }
 
 func fetchLatestSystemConfig() (*systemConfigSnapshot, error) {

--- a/fund-management-api/scripts/merge_pdf.js
+++ b/fund-management-api/scripts/merge_pdf.js
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+const path = require('path');
+
+async function loadPdfLib() {
+  try {
+    return require('pdf-lib');
+  } catch (error) {
+    console.error('Unable to load pdf-lib. Ensure NODE_PATH includes a directory containing pdf-lib.');
+    throw error;
+  }
+}
+
+async function mergePDFs(outputPath, inputPaths) {
+  if (inputPaths.length === 0) {
+    throw new Error('No input PDF files provided');
+  }
+
+  const { PDFDocument } = await loadPdfLib();
+  const mergedPdf = await PDFDocument.create();
+
+  for (const input of inputPaths) {
+    const absolutePath = path.resolve(input);
+    const data = await fs.promises.readFile(absolutePath);
+    const src = await PDFDocument.load(data);
+    const pages = await mergedPdf.copyPages(src, src.getPageIndices());
+    for (const page of pages) {
+      mergedPdf.addPage(page);
+    }
+  }
+
+  const mergedBytes = await mergedPdf.save();
+  await fs.promises.writeFile(path.resolve(outputPath), mergedBytes);
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.length < 2) {
+    console.error('Usage: merge_pdf.js <output> <input1> <input2> ...');
+    process.exit(1);
+  }
+
+  const [output, ...inputs] = args;
+  try {
+    await mergePDFs(output, inputs);
+  } catch (error) {
+    console.error(error && error.stack ? error.stack : error.message || String(error));
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- add frontend preview state management and wire the "ดูตัวอย่าง" control to call the publication reward preview API
- extend the preview controller to process multipart form submissions and delegate PDF merging to a Node-based helper
- introduce a pdf-lib powered merge script that combines the generated template PDF with user attachments

## Testing
- `cd fund-management-api && GOPROXY=off go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68d67327c47c832aa2ed176d8925399e