### PR TITLE
Handle preview conversion failures gracefully

### DIFF
--- a/frontend_project_fund/app/member/components/applications/PublicationRewardForm.js
+++ b/frontend_project_fund/app/member/components/applications/PublicationRewardForm.js
@@ -1879,7 +1879,11 @@ export default function PublicationRewardForm({ onNavigate, categoryId, yearId, 
         previewWindow.close();
       }
 
-      const message = error?.message || 'ไม่สามารถสร้างตัวอย่างได้';
+      let message = error?.message || 'ไม่สามารถสร้างตัวอย่างได้';
+
+      if (message && message.toLowerCase().includes('failed to read generated pdf')) {
+        message = 'ระบบไม่สามารถสร้างไฟล์ตัวอย่าง PDF ได้ในขณะนี้ กรุณาติดต่อผู้ดูแลระบบเพื่อตรวจสอบบริการแปลงเอกสาร';
+      }
 
       setPreviewState((prev) => ({
         ...prev,
@@ -1889,7 +1893,9 @@ export default function PublicationRewardForm({ onNavigate, categoryId, yearId, 
       }));
 
       Toast.fire({ icon: 'error', title: 'ไม่สามารถสร้างตัวอย่างได้', text: message });
-      throw error;
+      const wrappedError = new Error(message);
+      wrappedError.originalError = error;
+      throw wrappedError;
     }
   };
 


### PR DESCRIPTION
## Summary
- improve the publication reward preview error handling so users see a clear message when PDF generation fails
- wrap the thrown error with the user-facing message to avoid exposing the low-level backend text

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6ed22669c832ab968cb7525e5d66a