### PR TITLE
Ensure employment date appears in publication reward preview

### DIFF
--- a/fund-management-api/controllers/submission.go
+++ b/fund-management-api/controllers/submission.go
@@ -633,7 +633,7 @@ func buildSubmissionPreviewReplacements(submission *models.Submission, detail *m
 	replacements := map[string]string{
 		"{{date_th}}":            utils.FormatThaiDate(documentDate),
 		"{{applicant_name}}":     buildApplicantName(submission.User),
-		"{{date_of_employment}}": utils.FormatThaiDatePtr(submission.User.DateOfEmployment),
+		"{{date_of_employment}}": resolveApplicantEmploymentDate(submission.User),
 		"{{position}}":           positionName,
 		"{{installment}}":        formatNullableInt(sysConfig.Installment),
 		"{{total_amount}}":       formatAmount(detail.TotalAmount),


### PR DESCRIPTION
## Summary
- include the authenticated user id when building publication reward preview replacements so we can fetch the employment date from the database when it is missing from the form payload
- add a helper that loads and formats the applicant's employment date for preview requests

## Testing
- go test ./... *(fails: module root does not contain a Go module)*
- (cd fund-management-api && go test ./...) *(fails: hangs waiting for unavailable external dependencies, interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68de4dcd5ef0832aa167edb58bd198cd