### PR TITLE
Fix publication reward document line missing file names

### DIFF
--- a/fund-management-api/controllers/publication_reward_preview.go
+++ b/fund-management-api/controllers/publication_reward_preview.go
@@ -694,6 +694,7 @@ func fetchSubmissionDocuments(db *gorm.DB, submissionID int) ([]models.Submissio
 	var documents []models.SubmissionDocument
 	if err := db.
 		Preload("DocumentType").
+		Preload("File").
 		Where("submission_id = ?", submissionID).
 		Order("display_order ASC, document_id ASC").
 		Find(&documents).Error; err != nil {
@@ -805,6 +806,12 @@ func buildDocumentLine(documents []models.SubmissionDocument) string {
 		name := strings.TrimSpace(doc.DocumentTypeName)
 		if name == "" {
 			name = strings.TrimSpace(doc.DocumentType.DocumentTypeName)
+		}
+		if name == "" {
+			name = strings.TrimSpace(doc.Description)
+		}
+		if name == "" {
+			name = strings.TrimSpace(doc.File.OriginalName)
 		}
 		if name == "" {
 			continue


### PR DESCRIPTION
## Summary
- load submission documents with their file metadata when building publication reward outputs
- fall back to document descriptions or original file names so the document line never renders empty entries

## Testing
- go test ./... *(aborted locally due to long runtime)*

------
https://chatgpt.com/codex/tasks/task_e_68de52821134832aa4ccd95d21e1d585