### PR TITLE
Align generic fund submission status handling

### DIFF
--- a/frontend_project_fund/app/lib/status_service.js
+++ b/frontend_project_fund/app/lib/status_service.js
@@ -93,6 +93,17 @@ export async function getStatusIdByName(statusName) {
   return match ? match.application_status_id : undefined;
 }
 
+export async function getStatusIdByCode(statusCode) {
+  if (statusCode == null) {
+    return undefined;
+  }
+
+  const statuses = await statusService.fetchAll();
+  const normalizedCode = String(statusCode);
+  const match = statuses.find((status) => String(status.status_code) === normalizedCode);
+  return match ? match.application_status_id : undefined;
+}
+
 export function buildStatusMaps(statuses = []) {
   const byId = {};
   const byName = {};

--- a/frontend_project_fund/app/member/components/applications/GenericFundApplicationForm.js
+++ b/frontend_project_fund/app/member/components/applications/GenericFundApplicationForm.js
@@ -12,7 +12,10 @@ import { PDFDocument } from "pdf-lib";
 // เพิ่ม apiClient สำหรับเรียก API โดยตรง
 import apiClient from '../../../lib/api';
 import { submissionAPI, documentAPI, fileAPI} from '../../../lib/member_api';
-import { getStatusIdByName } from '../../../lib/status_service';
+import { getStatusIdByCode } from '../../../lib/status_service';
+
+// Match backend utils.StatusCodeDeptHeadPending for initial submission status
+const DEPT_HEAD_PENDING_STATUS_CODE = '5';
 
 // =================================================================
 // FILE UPLOAD COMPONENT
@@ -688,9 +691,9 @@ export default function GenericFundApplicationForm({ onNavigate, subcategoryData
     try {
       setSubmitting(true);
 
-      const deptPendingStatusId = await getStatusIdByName('อยู่ระหว่างการพิจารณาจากหัวหน้าสาขา');
+      const deptPendingStatusId = await getStatusIdByCode(DEPT_HEAD_PENDING_STATUS_CODE);
       if (!deptPendingStatusId) {
-        throw new Error('ไม่พบสถานะ "อยู่ระหว่างการพิจารณาจากหัวหน้าสาขา"');
+        throw new Error('ไม่พบสถานะสำหรับการพิจารณาของหัวหน้าสาขา');
       }
 
       // Step 1: Create submission record


### PR DESCRIPTION
## Summary
- add status lookup helper that resolves IDs by status code
- update generic fund submission flow to use dept-head pending status code when creating submissions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de766eeec8832a98661b8c98b99908