### PR TITLE
Fix year exposure for submission listings

### DIFF
--- a/frontend_project_fund/app/member/components/applications/ApplicationList.js
+++ b/frontend_project_fund/app/member/components/applications/ApplicationList.js
@@ -86,6 +86,17 @@ export default function ApplicationList({ onNavigate }) {
               ? getLabelById(statusId)
               : undefined);
 
+          const resolvedYear =
+            (typeof sub.year === 'object' ? sub.year?.year : sub.year) ??
+            sub.year_detail?.year ??
+            (typeof sub.Year === 'object' ? sub.Year?.year : sub.Year);
+
+          const resolvedYearId =
+            sub.year_id ??
+            sub.year_detail?.year_id ??
+            (typeof sub.year === 'object' ? sub.year?.year_id : undefined) ??
+            (typeof sub.Year === 'object' ? sub.Year?.year_id : undefined);
+
           const transformed = {
             application_id: sub.submission_id,
             application_number: sub.submission_number,
@@ -99,8 +110,8 @@ export default function ApplicationList({ onNavigate }) {
             status_id: statusId,
             status_fallback: fallbackStatusName,
             submitted_at: sub.created_at,
-            year: sub.year?.year || sub.Year?.year || '2568',
-            year_id: sub.year_id || sub.Year?.year_id,
+            year: resolvedYear ?? '-',
+            year_id: resolvedYearId,
             // Keep original data for reference
             _original: sub
           };

--- a/frontend_project_fund/app/member/components/funds/ReceivedFundsList.js
+++ b/frontend_project_fund/app/member/components/funds/ReceivedFundsList.js
@@ -27,19 +27,25 @@ export default function ReceivedFundsList({ onNavigate }) {
     try {
       const response = await submissionAPI.getSubmissions({ status: 2, limit: 1000 });
       if (response.success && Array.isArray(response.submissions)) {
-        const transformed = response.submissions.map((sub) => ({
-          submission_id: sub.submission_id,
-          submission_number: sub.submission_number,
-          category_name: sub.category_name || sub.category?.category_name || "-",
-          subcategory_name: sub.subcategory_name || sub.subcategory?.subcategory_name || "-",
-          year:
-            (typeof sub.year === "object" ? sub.year?.year : sub.year) ||
-            (typeof sub.Year === "object" ? sub.Year?.year : sub.Year) ||
-            "-",
-          year_id:
-            sub.year_id ||
-            sub.Year?.year_id ||
-            (typeof sub.year === "object" ? sub.year?.year_id : undefined),
+        const transformed = response.submissions.map((sub) => {
+          const resolvedYear =
+            (typeof sub.year === "object" ? sub.year?.year : sub.year) ??
+            sub.year_detail?.year ??
+            (typeof sub.Year === "object" ? sub.Year?.year : sub.Year);
+
+          const resolvedYearId =
+            sub.year_id ??
+            sub.year_detail?.year_id ??
+            (typeof sub.year === "object" ? sub.year?.year_id : undefined) ??
+            (typeof sub.Year === "object" ? sub.Year?.year_id : undefined);
+
+          return {
+            submission_id: sub.submission_id,
+            submission_number: sub.submission_number,
+            category_name: sub.category_name || sub.category?.category_name || "-",
+            subcategory_name: sub.subcategory_name || sub.subcategory?.subcategory_name || "-",
+            year: resolvedYear ?? "-",
+            year_id: resolvedYearId,
           approved_amount:
             sub.approved_amount ??
             sub.fund_application_detail?.approved_amount ??
@@ -48,7 +54,8 @@ export default function ReceivedFundsList({ onNavigate }) {
           status: sub.status?.status_name || "-",
           status_id: sub.status_id,
           _original: sub,
-        }));
+          };
+        });
         // Sort newest first by created_at
         transformed.sort(
           (a, b) =>

--- a/fund-management-api/controllers/admin_submission.go
+++ b/fund-management-api/controllers/admin_submission.go
@@ -35,7 +35,9 @@ func GetSubmissionDetails(c *gin.Context) {
 	// 1) โหลด submission + ความสัมพันธ์หลักแบบกันพลาด
 	q := config.DB.
 		Preload("User"). // เจ้าของคำร้อง
-		Preload("Year").
+		Preload("YearDetail").
+		Joins("LEFT JOIN years ON years.year_id = submissions.year_id").
+		Select("submissions.*, years.year AS year").
 		Preload("Status").
 		Preload("Category").
 		Preload("Subcategory").
@@ -180,7 +182,8 @@ func GetSubmissionDetails(c *gin.Context) {
 			"created_at":            s.CreatedAt,
 			"updated_at":            s.UpdatedAt,
 			"user":                  s.User, // owner object (อาจเป็น nil ได้)
-			"year":                  s.Year,
+			"year":                  s.YearDisplay,
+			"year_detail":           s.YearDetail,
 			"status":                s.Status,
 			"category":              s.Category,
 			"subcategory":           s.Subcategory,

--- a/fund-management-api/controllers/dept_head_submission.go
+++ b/fund-management-api/controllers/dept_head_submission.go
@@ -378,7 +378,9 @@ func DeptHeadRejectSubmission(c *gin.Context) {
 func buildSubmissionDetailPayload(submissionID int) (gin.H, error) {
 	var submission models.Submission
 	query := config.DB.Preload("User").
-		Preload("Year").
+		Preload("YearDetail").
+		Joins("LEFT JOIN years ON years.year_id = submissions.year_id").
+		Select("submissions.*, years.year AS year").
 		Preload("Status").
 		Preload("FundApplicationDetail.Subcategory.Category").
 		Preload("PublicationRewardDetail")
@@ -416,7 +418,8 @@ func buildSubmissionDetailPayload(submissionID int) (gin.H, error) {
 			"created_at":            submission.CreatedAt,
 			"updated_at":            submission.UpdatedAt,
 			"user":                  submission.User,
-			"year":                  submission.Year,
+			"year":                  submission.YearDisplay,
+			"year_detail":           submission.YearDetail,
 			"status":                submission.Status,
 		},
 		"details":          nil,

--- a/fund-management-api/controllers/submission.go
+++ b/fund-management-api/controllers/submission.go
@@ -39,7 +39,9 @@ func GetSubmissions(c *gin.Context) {
 
 	var submissions []models.Submission
 	query := config.DB.Preload("User").
-		Preload("Year").
+		Preload("YearDetail").
+		Joins("LEFT JOIN years ON years.year_id = submissions.year_id").
+		Select("submissions.*, years.year AS year").
 		Preload("Status").
 		Preload("Category").
 		Preload("Subcategory").
@@ -108,11 +110,12 @@ func GetSubmission(c *gin.Context) {
 
 	var submission models.Submission
 	query := config.DB.Model(&models.Submission{}).
+		Joins("LEFT JOIN years ON years.year_id = submissions.year_id").
 		Joins("LEFT JOIN fund_categories ON submissions.category_id = fund_categories.category_id").
 		Joins("LEFT JOIN fund_subcategories ON fund_subcategories.subcategory_id = submissions.subcategory_id AND fund_subcategories.category_id = submissions.category_id").
-		Select("submissions.*, fund_categories.category_name AS category_name, CASE WHEN fund_subcategories.subcategory_id IS NULL THEN NULL ELSE submissions.subcategory_id END AS subcategory_id, fund_subcategories.subcategory_name AS subcategory_name").
+		Select("submissions.*, years.year AS year, fund_categories.category_name AS category_name, CASE WHEN fund_subcategories.subcategory_id IS NULL THEN NULL ELSE submissions.subcategory_id END AS subcategory_id, fund_subcategories.subcategory_name AS subcategory_name").
 		Preload("User").
-		Preload("Year").
+		Preload("YearDetail").
 		Preload("Status").
 		Preload("Documents", func(db *gorm.DB) *gorm.DB {
 			return db.Joins("LEFT JOIN document_types dt ON dt.document_type_id = submission_documents.document_type_id").
@@ -282,7 +285,11 @@ func CreateSubmission(c *gin.Context) {
 		return
 	}
 
-	config.DB.Preload("User").Preload("Year").Preload("Status").First(&submission, submission.SubmissionID)
+	config.DB.Preload("User").Preload("YearDetail").
+		Joins("LEFT JOIN years ON years.year_id = submissions.year_id").
+		Select("submissions.*, years.year AS year").
+		Preload("Status").
+		First(&submission, submission.SubmissionID)
 	c.JSON(http.StatusCreated, gin.H{
 		"success":    true,
 		"message":    "Submission created successfully",

--- a/fund-management-api/controllers/submission_listing.go
+++ b/fund-management-api/controllers/submission_listing.go
@@ -60,7 +60,9 @@ func GetAllSubmissions(c *gin.Context) {
 
 	// Build base query
 	var submissions []models.Submission
-	query := config.DB.Preload("User").Preload("Year").Preload("Status").
+	query := config.DB.Preload("User").Preload("YearDetail").Preload("Status").
+		Joins("LEFT JOIN years ON years.year_id = submissions.year_id").
+		Select("submissions.*, years.year AS year").
 		Where("deleted_at IS NULL")
 
 	// Permission-based filtering
@@ -158,10 +160,11 @@ func GetTeacherSubmissions(c *gin.Context) {
 
 	// Build query for teacher's submissions
 	var submissions []models.Submission
-	query := config.DB.Preload("Year").Preload("Status").Preload("Category").
+	query := config.DB.Preload("YearDetail").Preload("Status").Preload("Category").
+		Joins("LEFT JOIN years ON years.year_id = submissions.year_id").
 		Joins("LEFT JOIN fund_categories ON submissions.category_id = fund_categories.category_id").
 		Joins("LEFT JOIN fund_subcategories ON fund_subcategories.subcategory_id = submissions.subcategory_id AND fund_subcategories.category_id = submissions.category_id").
-		Select("submissions.*, fund_categories.category_name AS category_name, CASE WHEN fund_subcategories.subcategory_id IS NULL THEN NULL ELSE submissions.subcategory_id END AS subcategory_id, fund_subcategories.subcategory_name AS subcategory_name").
+		Select("submissions.*, years.year AS year, fund_categories.category_name AS category_name, CASE WHEN fund_subcategories.subcategory_id IS NULL THEN NULL ELSE submissions.subcategory_id END AS subcategory_id, fund_subcategories.subcategory_name AS subcategory_name").
 		Where("submissions.user_id = ? AND submissions.deleted_at IS NULL", userID)
 
 	// Apply filters
@@ -249,7 +252,9 @@ func GetStaffSubmissions(c *gin.Context) {
 
 	// Build query for submissions that need staff review
 	var submissions []models.Submission
-	query := config.DB.Preload("User").Preload("Year").Preload("Status").Preload("Category").Preload("Subcategory").
+	query := config.DB.Preload("User").Preload("YearDetail").Preload("Status").Preload("Category").Preload("Subcategory").
+		Joins("LEFT JOIN years ON years.year_id = submissions.year_id").
+		Select("submissions.*, years.year AS year").
 		Where("deleted_at IS NULL AND submitted_at IS NOT NULL") // Only submitted submissions
 
 	// Apply filters
@@ -344,7 +349,9 @@ func GetAdminSubmissions(c *gin.Context) {
 
 	// ---------- Base list query (with preloads) ----------
 	var submissions []models.Submission
-	listQ := config.DB.Preload("User").Preload("Year").Preload("Status").Preload("Category").Preload("Subcategory").
+	listQ := config.DB.Preload("User").Preload("YearDetail").Preload("Status").Preload("Category").Preload("Subcategory").
+		Joins("LEFT JOIN years ON years.year_id = submissions.year_id").
+		Select("submissions.*, years.year AS year").
 		Where("submissions.deleted_at IS NULL")
 
 	// Apply filters (identical set used later for stats)
@@ -524,7 +531,9 @@ func SearchSubmissions(c *gin.Context) {
 	var submissions []models.Submission
 	searchTerm := "%" + keyword + "%"
 
-	query := config.DB.Preload("User").Preload("Year").Preload("Status").
+	query := config.DB.Preload("User").Preload("YearDetail").Preload("Status").
+		Joins("LEFT JOIN years ON years.year_id = submissions.year_id").
+		Select("submissions.*, years.year AS year").
 		Where("deleted_at IS NULL")
 
 	// Permission-based filtering

--- a/fund-management-api/models/submission.go
+++ b/fund-management-api/models/submission.go
@@ -13,6 +13,7 @@ type Submission struct {
 	SubmissionType          string     `gorm:"column:submission_type" json:"submission_type"`
 	UserID                  int        `gorm:"column:user_id" json:"user_id"`
 	YearID                  int        `gorm:"column:year_id" json:"year_id"`
+	YearDisplay             *string    `gorm:"column:year;->" json:"year,omitempty"`
 	CategoryID              *int       `gorm:"column:category_id" json:"category_id"`                     // ✅ เพิ่มใหม่
 	CategoryName            *string    `gorm:"column:category_name;->" json:"category_name"`              // ✅ เพิ่มใหม่ (read-only, มาจาก join)
 	SubcategoryID           *int       `gorm:"column:subcategory_id" json:"subcategory_id"`               // ✅ เพิ่มใหม่
@@ -29,7 +30,7 @@ type Submission struct {
 
 	// Relations
 	User                    *User                    `gorm:"foreignKey:UserID" json:"user,omitempty"`
-	Year                    Year                     `gorm:"foreignKey:YearID" json:"year,omitempty"`
+	YearDetail              *Year                    `gorm:"foreignKey:YearID" json:"year_detail,omitempty"`
 	Status                  ApplicationStatus        `gorm:"foreignKey:StatusID" json:"status,omitempty"`
 	Category                *FundCategory            `gorm:"foreignKey:CategoryID" json:"category,omitempty"`
 	Subcategory             *FundSubcategory         `gorm:"foreignKey:SubcategoryID" json:"subcategory,omitempty"`


### PR DESCRIPTION
## Summary
- add an explicit year string on submissions while keeping the year relation under `year_detail`
- join the years table across submission listing/detail queries so the API surfaces the selected year
- update member-facing lists to read the resolved year field rather than showing a dash by default

## Testing
- go test ./... *(hangs while waiting on external dependencies, interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68de8675590c832a8c92e04f714fcfd9