### PR TITLE
Add deployment instructions for frontend and backend

### DIFF
--- a/frontend_project_fund/README.md
+++ b/frontend_project_fund/README.md
@@ -1,37 +1,102 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
+# Frontend Deployment Guide
 
-## Getting Started
+This document explains how to deploy and update the Next.js frontend for the fund management platform.
 
-First, run the development server:
+## 1. Prerequisites
+
+Install the following packages on the target server:
+
+- `git`
+- Build tools (`build-essential` on Debian/Ubuntu)
+- SSL libraries (`libssl-dev`)
+- Node.js **LTS** (18.x or newer) and either `npm` or `yarn`
+
+```bash
+# Debian / Ubuntu example
+sudo apt update
+sudo apt install -y git build-essential libssl-dev
+curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash -
+sudo apt install -y nodejs
+```
+
+## 2. Initial Deployment
+
+```bash
+# Clone the repository
+cd /opt
+sudo git clone https://<your-git-host>/fund-management-unify.git
+sudo chown -R $USER:$USER fund-management-unify
+
+# Enter the frontend project
+cd fund-management-unify/frontend_project_fund
+
+# Install dependencies
+npm install
+# or
+# yarn install
+```
+
+## 3. Environment Configuration
+
+Create an `.env.local` file in `frontend_project_fund` with the required environment variables:
+
+```bash
+cp .env.local.example .env.local  # if you maintain an example file
+```
+
+Define at least the following variables (values will depend on your backend deployment):
+
+```bash
+NEXT_PUBLIC_API_URL=https://api.example.com/api/v1
+BACKEND_URL=https://api.example.com
+```
+
+Add any other secrets the application expects. Never commit real credentials to Git.
+
+## 4. Build and Run (Production)
+
+```bash
+# Build optimized assets
+npm run build
+# or
+# yarn build
+
+# Start the production server
+npm run start
+# or use your process manager, e.g.:
+# npx pm2 start npm --name fund-frontend -- run start
+```
+
+Run the start command inside a process manager (PM2, systemd, etc.) when deploying permanently.
+
+## 5. Optional: Development Mode
+
+For debugging on a staging environment:
 
 ```bash
 npm run dev
 # or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+# yarn dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Development mode should not be used on the public server.
 
-You can start editing the page by modifying `app/page.js`. The page auto-updates as you edit the file.
+## 6. Updating an Existing Deployment
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+```bash
+cd /opt/fund-management-unify/frontend_project_fund
 
-## Learn More
+# Pull latest changes
+git pull
 
-To learn more about Next.js, take a look at the following resources:
+# Install updated dependencies
+npm install
+# or
+# yarn install
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+# Rebuild and restart the service
+npm run build
+npm run start  # replace with your process manager command
+```
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
-# frontend_project_plan
+Ensure any new environment variables introduced in updates are applied to `.env.local` before restarting the service.

--- a/fund-management-api/README.md
+++ b/fund-management-api/README.md
@@ -1,1 +1,122 @@
-# fund-management-api
+# Backend Deployment Guide
+
+This guide documents how to deploy and maintain the Go (Gin + GORM) API for the fund management platform.
+
+## 1. Prerequisites
+
+Install the required system packages on the server:
+
+- `git`
+- Build essentials (`build-essential`, `libssl-dev` on Debian/Ubuntu)
+- LibreOffice (for publication reward PDF rendering)
+- Go **1.21+** (or the version declared in `go.mod`)
+- MariaDB/MySQL server and client libraries (for example `mariadb-server` and `libmariadb-dev`)
+
+```bash
+# Debian / Ubuntu example
+sudo apt update
+sudo apt install -y git build-essential libssl-dev libreoffice mariadb-server libmariadb-dev
+
+# Install Go 1.21+
+wget https://go.dev/dl/go1.21.6.linux-amd64.tar.gz
+sudo rm -rf /usr/local/go
+sudo tar -C /usr/local -xzf go1.21.6.linux-amd64.tar.gz
+export PATH=$PATH:/usr/local/go/bin
+```
+
+Create a database and user for the application before running the API.
+
+## 2. Initial Deployment
+
+```bash
+# Clone the repository
+cd /opt
+sudo git clone https://<your-git-host>/fund-management-unify.git
+sudo chown -R $USER:$USER fund-management-unify
+
+# Enter the backend project
+cd fund-management-unify/fund-management-api
+
+# Sync dependencies
+go mod tidy
+```
+
+## 3. Environment Configuration
+
+Copy the sample environment file and adjust values for your environment:
+
+```bash
+cp .env.example .env
+```
+
+Set at minimum the following variables (see `.env.example` for the full list):
+
+- `DB_HOST`, `DB_PORT`, `DB_DATABASE`, `DB_USERNAME`, `DB_PASSWORD`
+- `SERVER_PORT`
+- `GIN_MODE=release` in production
+- `JWT_SECRET`, `JWT_EXPIRE_HOURS`, `REFRESH_TOKEN_EXPIRE_HOURS`
+- `UPLOAD_PATH` (directory for uploaded files)
+- Email/notification settings if used (`SMTP_*`, `APP_BASE_URL`)
+
+Ensure the directories referenced by `UPLOAD_PATH` and `LOG_FILE` exist and are writable by the service user.
+
+## 4. Database Migrations
+
+Import the provided SQL schema that matches your target version (for example `fund_cpkku_v42.sql`).
+
+```bash
+mysql -u <db_user> -p<db_password> <db_name> < ../fund_cpkku_v42.sql
+```
+
+Run migrations again whenever a new SQL dump or migration script is added to the repository.
+
+## 5. Build and Run
+
+```bash
+# Build the API binary
+go build -o fund-api ./cmd/api
+
+# Run manually (for testing)
+./fund-api
+```
+
+For persistent deployments, run the binary with a process manager. Example `systemd` service (`/etc/systemd/system/fund-api.service`):
+
+```ini
+[Unit]
+Description=Fund Management API
+After=network.target mariadb.service
+
+[Service]
+Type=simple
+User=www-data
+WorkingDirectory=/opt/fund-management-unify/fund-management-api
+EnvironmentFile=/opt/fund-management-unify/fund-management-api/.env
+ExecStart=/opt/fund-management-unify/fund-management-api/fund-api
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Reload systemd and start the service:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now fund-api.service
+```
+
+## 6. Updating an Existing Deployment
+
+```bash
+cd /opt/fund-management-unify/fund-management-api
+
+git pull
+
+go mod tidy
+
+go build -o fund-api ./cmd/api
+sudo systemctl restart fund-api.service  # or restart your process manager
+```
+
+Check the release notes or diff for new environment variables or database migrations before restarting the service.


### PR DESCRIPTION
## Summary
- replace the autogenerated Next.js README with production-focused deployment instructions for the frontend
- document backend prerequisites, configuration, build steps, and service management guidance

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df9c8c4434832a91da6666a73b4857