### PR TITLE
Fix LibreOffice profile path on Windows

### DIFF
--- a/fund-management-api/.env.example
+++ b/fund-management-api/.env.example
@@ -83,3 +83,8 @@ CACHE_TTL=3600                       # Cache timeout (วินาที)
 AUTO_BACKUP_ENABLED=false            # สำรองข้อมูลอัตโนมัติ
 BACKUP_SCHEDULE=0 2 * * *            # ทุกวันเวลา 02:00 (cron format)
 BACKUP_RETENTION_DAYS=30             # เก็บ backup 30 วัน
+
+# Document Generation Configuration
+# Path to LibreOffice soffice executable (set this on Windows servers)
+# Example: "C:/Program Files/LibreOffice/program/soffice.exe"
+LIBREOFFICE_PATH=


### PR DESCRIPTION
## Summary
- build a file URL for the temporary LibreOffice profile directory so the headless conversion works on Windows paths
- add a helper that normalizes local paths (including UNC shares) into file:// URIs used when launching LibreOffice
- allow overriding the LibreOffice binary with a LIBREOFFICE_PATH environment variable documented in the sample .env file

## Testing
- timeout 60 go test ./... *(terminated because it hung; requires external dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68dfcbf60400832a81d688373c7a2612