### PR TITLE
Align admin promotion fund view with member read-only display

### DIFF
--- a/frontend_project_fund/app/admin/components/funds/PromotionFundContent.js
+++ b/frontend_project_fund/app/admin/components/funds/PromotionFundContent.js
@@ -1,38 +1,42 @@
-// app/teacher/components/funds/PromotionFundContent.js - ทุนอุดหนุนกิจกรรม (Enhanced UI)
+// app/teacher/components/funds/PromotionFundContent.js - ทุนอุดหนุนกิจกรรม (Using New API)
 "use client";
 
 import { useState, useEffect, useRef } from "react";
-import { TrendingUp, ExternalLink, FileText, Search, Filter, ChevronDown, Eye, Download, X, Info } from "lucide-react";
+import { TrendingUp, Search, Download, X, Info, Clock, AlertTriangle } from "lucide-react";
 import PageLayout from "../common/PageLayout";
-import Card from "../common/Card";
 import { teacherAPI } from '../../../lib/member_api';
-import { targetRolesUtils } from '../../../lib/target_roles_utils';
+import { targetRolesUtils, filterFundsByRole } from '../../../lib/target_roles_utils';
+import { FORM_TYPE_CONFIG } from '../../../lib/form_type_config';
+import systemConfigAPI from '../../../lib/system_config_api';
 
 export default function PromotionFundContent({ onNavigate }) {
-  const [selectedYear, setSelectedYear] = useState("2566");
+  const [selectedYear, setSelectedYear] = useState("2568");
   const [fundCategories, setFundCategories] = useState([]);
   const [filteredFunds, setFilteredFunds] = useState([]);
   const [years, setYears] = useState([]);
+  const [systemConfig, setSystemConfig] = useState(null);
+  const [isWithinApplicationPeriod, setIsWithinApplicationPeriod] = useState(true);
+  const [endDateLabel, setEndDateLabel] = useState(""); // <— NEW: for appending to fund_condition
   const [loading, setLoading] = useState(true);
   const [yearsLoading, setYearsLoading] = useState(false);
+  const [configLoading, setConfigLoading] = useState(false);
   const [error, setError] = useState(null);
   const [userRole, setUserRole] = useState(null);
   
   // Filter states
   const [searchTerm, setSearchTerm] = useState("");
   const [statusFilter, setStatusFilter] = useState("all");
-  const [showFilters, setShowFilters] = useState(false);
   
   // Modal state for fund condition
   const [showConditionModal, setShowConditionModal] = useState(false);
   const [selectedCondition, setSelectedCondition] = useState({ title: '', content: '' });
-  const modalRef = useRef(null); // Create a ref for the modal container
+  const modalRef = useRef(null);
 
   useEffect(() => {
     if (showConditionModal && modalRef.current) {
-      modalRef.current.focus(); // Focus the modal when it opens
+      modalRef.current.focus();
     }
-  }, [showConditionModal]); // Run when showConditionModal changes
+  }, [showConditionModal]);
 
   useEffect(() => {
     loadInitialData();
@@ -40,27 +44,64 @@ export default function PromotionFundContent({ onNavigate }) {
 
   useEffect(() => {
     if (selectedYear) {
-      loadFundData(selectedYear);
+      loadFundData(selectedYear, userRole);
     }
-  }, [selectedYear]);
+  }, [selectedYear, userRole, isWithinApplicationPeriod, endDateLabel]); // reload when window status/label changes
 
   useEffect(() => {
     applyFilters();
   }, [searchTerm, statusFilter, fundCategories]);
+
+  // ---------- helpers ----------
+  // Accepts "YYYY-MM-DD HH:mm:ss" (treated as local) or ISO (respects Z/offset)
+  const computeApplicationOpen = (start, end) => {
+    if (!start || !end) return true; // if not configured => allow
+    const parse = (v) => {
+      if (v == null) return NaN;
+      const s = String(v).trim();
+      // If it already has timezone info (Z or ±HH:MM), let Date handle it
+      if (/[zZ]|[+\-]\d{2}:\d{2}$/.test(s)) return new Date(s);
+      // Otherwise treat SQL-like as local time by inserting 'T'
+      return new Date(s.replace(" ", "T"));
+    };
+    const s = parse(start);
+    const e = parse(end);
+    if (isNaN(s) || isNaN(e)) return true;
+
+    const now = new Date();
+    // inclusive window: start <= now <= end
+    return s.getTime() <= now.getTime() && now.getTime() <= e.getTime();
+  };
+
+
+  // Thai date (date only) like "1 มกราคม 2569"
+  const formatThaiDate = (value) => {
+    if (!value) return "";
+    const d = new Date(String(value).replace(" ", "T"));
+    if (isNaN(d.getTime())) return "";
+    const thaiMonths = [
+      'มกราคม', 'กุมภาพันธ์', 'มีนาคม', 'เมษายน', 'พฤษภาคม', 'มิถุนายน',
+      'กรกฎาคม', 'สิงหาคม', 'กันยายน', 'ตุลาคม', 'พฤศจิกายน', 'ธันวาคม'
+    ];
+    return `${d.getDate()} ${thaiMonths[d.getMonth()]} ${d.getFullYear() + 543}`;
+  };
 
   const loadInitialData = async () => {
     try {
       setLoading(true);
       setError(null);
 
-      const [roleInfo, yearsData] = await Promise.all([
+      const [roleInfo, yearsData, configData] = await Promise.all([
         targetRolesUtils.getCurrentUserRole(),
-        loadAvailableYears()
+        loadAvailableYears(),
+        loadSystemConfig()
       ]);
 
       setUserRole(roleInfo);
       setYears(yearsData);
-      await loadFundData(selectedYear);
+      setSystemConfig(configData);
+
+      // funds will reload via selectedYear effect
     } catch (err) {
       console.error('Error loading initial data:', err);
       setError(err.message || 'เกิดข้อผิดพลาดในการโหลดข้อมูล');
@@ -92,72 +133,215 @@ export default function PromotionFundContent({ onNavigate }) {
     }
   };
 
-  const loadFundData = async (year) => {
+  // === build Authorization header from localStorage (no TS) ===
+  const buildAuthHeader = () => {
+    if (typeof window === "undefined") return null;
+    const raw =
+      localStorage.getItem("access_token") ||
+      localStorage.getItem("token") ||
+      localStorage.getItem("auth_token");
+    if (!raw) return null;
+    return /^Bearer\s+/i.test(raw) ? raw : `Bearer ${raw}`;
+  };
+
+  // REPLACE: whole function
+  const loadSystemConfig = async () => {
+    try {
+      setConfigLoading(true);
+
+      // เรียกตรง backend ผ่าน apiClient (ไม่ผ่าน /app/api/* อีกแล้ว)
+      const res = await systemConfigAPI.getWindow();
+      const win = systemConfigAPI.normalizeWindow(res);
+
+      // กันค่าผิดปกติ
+      const norm = (v) => {
+        if (!v) return null;
+        const s = String(v).trim();
+        if (!s || s === '0000-00-00 00:00:00') return null;
+        return s;
+      };
+
+      const start_date = norm(win.start_date);
+      const end_date   = norm(win.end_date);
+
+      // ใช้ค่าสถานะเปิดจาก backend ถ้ามี ไม่งั้นคำนวณเอง
+      const open = (typeof win.is_open_effective === 'boolean')
+        ? win.is_open_effective
+        : computeApplicationOpen(start_date, end_date);
+
+      setIsWithinApplicationPeriod(open);
+      setEndDateLabel(end_date ? formatThaiDate(end_date) : '');
+      setSystemConfig({
+        start_date,
+        end_date,
+        is_open_effective: open,
+        current_year: win.current_year,
+        last_updated: win.last_updated,
+        now: win.now,
+      });
+
+      // debug ให้ดูบน console
+      console.log('[system-config]', {
+        start_date,
+        end_date,
+        is_open_effective: open,
+        now: win.now,
+      });
+
+      return { start_date, end_date, is_open_effective: open };
+    } catch (e) {
+      console.warn('loadSystemConfig failed:', e);
+      // อย่าบล็อกหน้า ถ้าโหลดไม่ได้ให้ถือว่าเปิดไว้ก่อน
+      setIsWithinApplicationPeriod(true);
+      setEndDateLabel('');
+      return null;
+    } finally {
+      setConfigLoading(false);
+    }
+  };
+
+
+  // (kept for banner rendering compatibility)
+  const checkApplicationPeriod = (config) => {
+    if (!config || !config.start_date || !config.end_date) {
+      setIsWithinApplicationPeriod(true); // Default to allow if no config
+      return;
+    }
+
+    const now = new Date();
+    const startDate = new Date(config.start_date);
+    const endDate = new Date(config.end_date);
+
+    // Check if dates are valid (not "0000-00-00 00:00:00")
+    if (config.start_date === "0000-00-00 00:00:00" || config.end_date === "0000-00-00 00:00:00") {
+      setIsWithinApplicationPeriod(true); // Allow if dates are not set
+      return;
+    }
+
+    const withinPeriod = now >= startDate && now <= endDate;
+    setIsWithinApplicationPeriod(withinPeriod);
+  };
+
+  const formatDateThai = (dateString) => {
+    if (!dateString || dateString === "0000-00-00 00:00:00") {
+      return 'ไม่ระบุ';
+    }
+
+    try {
+      const date = new Date(dateString);
+      if (isNaN(date.getTime())) return 'วันที่ไม่ถูกต้อง';
+
+      const thaiMonths = [
+        'มกราคม', 'กุมภาพันธ์', 'มีนาคม', 'เมษายน', 'พฤษภาคม', 'มิถุนายน',
+        'กรกฎาคม', 'สิงหาคม', 'กันยายน', 'ตุลาคม', 'พฤศจิกายน', 'ธันวาคม'
+      ];
+
+      const day = date.getDate();
+      const month = thaiMonths[date.getMonth()];
+      const year = date.getFullYear() + 543; // Convert to Buddhist year
+      const hours = date.getHours().toString().padStart(2, '0');
+      const minutes = date.getMinutes().toString().padStart(2, '0');
+
+      return `${day} ${month} ${year} เวลา ${hours}:${minutes} น.`;
+    } catch (err) {
+      return 'วันที่ไม่ถูกต้อง';
+    }
+  };
+
+  const getDaysUntilDeadline = () => {
+    if (!systemConfig || !systemConfig.end_date || systemConfig.end_date === "0000-00-00 00:00:00") {
+      return null;
+    }
+
+    try {
+      const now = new Date();
+      const endDate = new Date(systemConfig.end_date);
+      const diffTime = endDate - now;
+      const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+      
+      return diffDays;
+    } catch (err) {
+      return null;
+    }
+  };
+
+  const loadFundData = async (year, roleContext = userRole) => {
     try {
       setLoading(true);
       setError(null);
-      
+
+      // ใช้ API ใหม่ที่ส่งข้อมูลแบบจัดกลุ่มแล้ว
       const response = await teacherAPI.getVisibleFundsStructure(year);
-      console.log('Full API Response:', response);
-      
+      console.log("Fund structure response:", response);
+
       if (!response.categories || !Array.isArray(response.categories)) {
-        console.error('No categories found or invalid format');
+        console.error("No categories found or invalid format");
         setFundCategories([]);
         return;
       }
-      
-      // กรองเฉพาะทุนอุดหนุนกิจกรรม (จากตาราง fund_categories)
-      const promotionFunds = response.categories.filter(category => {
-        const categoryName = category.category_name?.toLowerCase() || '';
-        // ตามข้อมูลในฐานข้อมูล category_id = 2 คือ 'ทุนอุดหนุนกิจกรรม'
-        return categoryName.includes('อุดหนุน') ||
-               categoryName.includes('กิจกรรม') ||
-               categoryName.includes('ส่งเสริม') ||
-               categoryName.includes('promotion') ||
-               categoryName.includes('activity') ||
-               category.category_id === 2;
-      });
 
-      // รวมทุนเงินรางวัลการตีพิมพ์ (ผู้แต่งชื่อแรก/ผู้ประพันธ์บรรณกิจ) ให้เป็นตัวเลือกเดียว
-      const mergedFunds = promotionFunds.map(category => {
+      const visibleCategories = filterFundsByRole(
+        response.categories,
+        roleContext?.role_id ?? roleContext?.role_name ?? roleContext
+      );
+
+      // กรองเฉพาะทุนอุดหนุนกิจกรรม (category_id = 2)
+      const promotionFunds = visibleCategories.filter(
+        (category) => category.category_id === 2
+      );
+
+      // รวมทุน publication_reward ให้เป็น 1 แถว (คงพฤติกรรมเดิม)
+      const mergedPromotionFunds = promotionFunds.map((category) => {
         if (!Array.isArray(category.subcategories)) return category;
 
         const publicationSubs = category.subcategories.filter(
-          sub => sub.form_type === 'publication_reward'
+          (sub) => sub.form_type === "publication_reward"
         );
 
         if (publicationSubs.length > 1) {
           const merged = {
             ...publicationSubs[0],
-            subcategory_name: 'เงินรางวัลการตีพิมพ์เผยแพร่ผลงานวิจัย',
+            category_id: category.category_id,
+            subcategory_name: "เงินรางวัลการตีพิมพ์เผยแพร่ผลงานวิจัย",
             remaining_budget: publicationSubs.reduce(
               (sum, s) => sum + (s.remaining_budget || 0),
               0
             ),
-            has_multiple_levels: publicationSubs.some(s => s.has_multiple_levels),
+            has_multiple_levels: publicationSubs.some((s) => s.has_multiple_levels),
             budget_count: publicationSubs.reduce(
               (sum, s) => sum + (s.budget_count || 0),
               0
             ),
-            merged_subcategories: publicationSubs
+            merged_subcategories: publicationSubs,
           };
 
           const others = category.subcategories.filter(
-            sub => sub.form_type !== 'publication_reward'
+            (sub) => sub.form_type !== "publication_reward"
           );
-
-          return { ...category, subcategories: [...others, merged] };
+          return { ...category, subcategories: [merged, ...others] };
         }
-
         return category;
       });
 
-      console.log('Promotion funds found:', mergedFunds);
-      setFundCategories(mergedFunds);
-      
+      const adjusted = mergedPromotionFunds.map((category) => {
+        const newSubs = (category.subcategories || []).map((sub) => {
+          let next = { ...sub };
+          if (!isWithinApplicationPeriod) {
+            const note = endDateLabel ? `\nสิ้นสุดรับคำขอ: ${endDateLabel}` : "";
+            const base = (next.fund_condition || "").trim();
+            const already = base.includes("สิ้นสุดรับคำขอ:");
+            next.fund_condition = already ? base : `${base}${note}`;
+          }
+          return next;
+        });
+        return { ...category, subcategories: newSubs };
+      });
+
+
+      setFundCategories(adjusted);
     } catch (err) {
-      console.error('Error loading fund data:', err);
-      setError(err.message || 'เกิดข้อผิดพลาดในการโหลดข้อมูลทุน');
+      console.error("Error loading fund data:", err);
+      setError(err.message || "เกิดข้อผิดพลาดในการโหลดข้อมูลทุน");
       setFundCategories([]);
     } finally {
       setLoading(false);
@@ -172,8 +356,7 @@ export default function PromotionFundContent({ onNavigate }) {
       filtered = filtered.map(category => ({
         ...category,
         subcategories: category.subcategories?.filter(sub => {
-          // ตรวจสอบทั้ง subcategorie_name และ subcategory_name
-          const subName = sub.subcategorie_name || sub.subcategory_name || '';
+          const subName = sub.subcategory_name || sub.subcategorie_name || '';
           const condition = sub.fund_condition || '';
           return subName.toLowerCase().includes(searchTerm.toLowerCase()) ||
                  condition.toLowerCase().includes(searchTerm.toLowerCase());
@@ -186,8 +369,7 @@ export default function PromotionFundContent({ onNavigate }) {
       filtered = filtered.map(category => ({
         ...category,
         subcategories: category.subcategories?.filter(sub => {
-          const isAvailable = sub.remaining_budget > 0 && 
-                            (sub.remaining_grant === null || sub.remaining_grant === undefined || sub.remaining_grant > 0);
+          const isAvailable = sub.remaining_budget > 0;
           return statusFilter === "available" ? isAvailable : !isAvailable;
         }) || []
       })).filter(category => category.subcategories && category.subcategories.length > 0);
@@ -200,23 +382,35 @@ export default function PromotionFundContent({ onNavigate }) {
     loadFundData(selectedYear);
   };
 
-  const handleViewForm = (subcategory) => {
-    // ตรวจสอบว่ามีหน้าฟอร์มออนไลน์หรือไม่
-    // ถ้าไม่มีข้อมูล has_online_form ให้ default เป็น false (ดาวน์โหลดฟอร์ม)
-    const hasOnlineForm = subcategory.has_online_form === true;
-    
-    if (hasOnlineForm) {
-      // ตรวจสอบว่ามี URL ฟอร์มออนไลน์ภายนอกหรือไม่
-      if (subcategory.online_form_url) {
-        // เปิดลิงก์ฟอร์มออนไลน์ภายนอกในแท็บใหม่
-        window.open(subcategory.online_form_url, '_blank');
-      } else if (onNavigate) {
-        // นำทางไปหน้าฟอร์มออนไลน์ภายในระบบ
-        onNavigate('application-form', { category_id: subcategory.category_id });
-      }
+  const findParentCategoryId = (subcategoryId) => {
+    const parent = fundCategories.find(cat =>
+      cat.subcategories?.some(sub => {
+        const currentId = sub.subcategory_id ?? sub.subcategorie_id;
+        return currentId === subcategoryId;
+      })
+    );
+    return parent?.category_id;
+  };
+
+  const handleViewDetails = (subcategory) => {
+    const formType = subcategory.form_type || 'download';
+    const formConfig = FORM_TYPE_CONFIG[formType] || {};
+    if (formConfig.isOnlineForm && onNavigate) {
+      const subcategoryId = subcategory.subcategory_id ?? subcategory.subcategorie_id;
+      const categoryId = findParentCategoryId(subcategoryId);
+      const yearObj = years.find(y => y.year === selectedYear);
+      const yearId = yearObj?.year_id;
+
+      try { sessionStorage.setItem('fund_form_readonly', '1'); } catch {}
+
+      // จะใส่ query ย้ำด้วยก็ได้: `${formConfig.route}?readonly=1`
+      onNavigate(formConfig.route, {
+        category_id: categoryId,
+        year_id: yearId,
+        subcategory,
+      });
     } else {
-      // แสดงลิงก์ดาวน์โหลดไฟล์ DOC
-      const docUrl = subcategory.form_document_url || '/documents/promotion-fund-form.docx';
+      const docUrl = subcategory.form_url || '/documents/default-fund-form.docx';
       window.open(docUrl, '_blank');
     }
   };
@@ -229,6 +423,67 @@ export default function PromotionFundContent({ onNavigate }) {
   const showCondition = (fundName, condition) => {
     setSelectedCondition({ title: fundName, content: condition });
     setShowConditionModal(true);
+  };
+
+  const renderApplicationPeriodInfo = () => {
+    if (!systemConfig) return null;
+
+    const daysUntilDeadline = getDaysUntilDeadline();
+    const endDateFormatted = formatDateThai(systemConfig.end_date);
+
+    if (!isWithinApplicationPeriod) {
+      return (
+        <div className="mb-6 bg-red-50 border border-red-200 rounded-lg p-4">
+          <div className="flex items-center gap-3">
+            <AlertTriangle className="text-red-600 flex-shrink-0" size={20} />
+            <div>
+              <h3 className="text-red-800 font-medium">หมดเวลาการยื่นขอทุน</h3>
+              <p className="text-red-700 text-sm mt-1">
+                การยื่นขอทุนได้สิ้นสุดลงเมื่อ {endDateFormatted}
+              </p>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    if (daysUntilDeadline !== null && daysUntilDeadline <= 7) {
+      return (
+        <div className="mb-6 bg-yellow-50 border border-yellow-200 rounded-lg p-4">
+          <div className="flex items-center gap-3">
+            <Clock className="text-yellow-600 flex-shrink-0" size={20} />
+            <div>
+              <h3 className="text-yellow-800 font-medium">
+                {daysUntilDeadline > 0 
+                  ? `เหลือเวลาอีก ${daysUntilDeadline} วัน` 
+                  : 'วันสุดท้ายของการยื่นขอทุน'}
+              </h3>
+              <p className="text-yellow-700 text-sm mt-1">
+                การยื่นขอทุนจะสิ้นสุดในวันที่ {endDateFormatted}
+              </p>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    if (systemConfig.end_date && systemConfig.end_date !== "0000-00-00 00:00:00") {
+      return (
+        <div className="mb-6 bg-blue-50 border border-blue-200 rounded-lg p-4">
+          <div className="flex items-center gap-3">
+            <Info className="text-blue-600 flex-shrink-0" size={20} />
+            <div>
+              <h3 className="text-blue-800 font-medium">ระยะเวลาการยื่นขอทุน</h3>
+              <p className="text-blue-700 text-sm mt-1">
+                สามารถยื่นขอทุนได้ถึงวันที่ {endDateFormatted}
+              </p>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    return null;
   };
 
   if (loading) {
@@ -258,80 +513,75 @@ export default function PromotionFundContent({ onNavigate }) {
     );
   }
 
-  // Helper function to render a single fund row
-  const renderFundRow = (fund, category, isAvailable) => {
-    // ตรวจสอบทั้ง subcategorie_name และ subcategory_name
-    const fundName = fund.subcategorie_name || fund.subcategory_name || 'ไม่ระบุชื่อทุน';
-    const fundId = fund.subcategorie_id || fund.subcategory_id;
-    const hasOnlineForm = fund.has_online_form === true;
-    const maxAmountPerGrant = fund.max_amount_per_grant || fund.allocated_amount;
-    
+  const renderFundRow = (fund, isAvailable) => {
+    const fundName = fund.subcategory_name || fund.subcategorie_name || 'ไม่ระบุ';
+    const remainingBudget = fund.remaining_budget ?? 0;
+    const formType = fund.form_type || 'download';
+    const formConfig = FORM_TYPE_CONFIG[formType] || {};
+    const isOnlineForm = !!formConfig.isOnlineForm;
+
+    const fundId = fund.subcategory_id ?? fund.subcategorie_id ?? `${fundName}-${formType}`;
+
     return (
-      <tr key={fundId} className={!isAvailable ? 'bg-gray-50' : ''}>
-        <td className="px-6 py-4 line-clamp-5">
-          <div className="text-sm font-medium text-gray-900">
+      <tr key={fundId} className={!isWithinApplicationPeriod || !isAvailable ? 'bg-gray-50' : ''}>
+        <td className="px-6 py-4">
+          <div className="text-sm font-medium text-gray-900 max-w-lg break-words leading-relaxed">
             {fundName}
           </div>
+          {fund.has_multiple_levels && (
+            <div className="text-xs text-gray-500 mt-1">
+              (มี {fund.budget_count} ระดับ)
+            </div>
+          )}
         </td>
         <td className="px-6 py-4">
           <div className="text-sm text-gray-900">
             {fund.fund_condition ? (
-              <div 
+              <button
                 onClick={() => showCondition(fundName, fund.fund_condition)}
-                className="line-clamp-2 cursor-pointer hover:text-blue-600 transition-colors duration-200"
-                title="คลิกเพื่ออ่านเงื่อนไขทั้งหมด"
+                className="text-blue-600 hover:text-blue-800 underline flex items-center gap-1"
               >
-                {fund.fund_condition}
-              </div>
+                <Info className="w-4 h-4" />
+                ดูเงื่อนไข
+              </button>
             ) : (
-              <span className="text-gray-400">ไม่ระบุเงื่อนไข</span>
+              <span className="text-gray-500">ไม่มีเงื่อนไขเฉพาะ</span>
             )}
           </div>
         </td>
         <td className="px-6 py-4">
-          <div className="space-y-1">
-            <div className="text-sm font-medium text-gray-900">
-              งบประมาณ: {formatAmount(fund.allocated_amount)}
-            </div>
-            <div className="text-xs text-gray-600">
-              คงเหลือ: {formatAmount(fund.remaining_budget)}
-            </div>
-            <div className="text-xs text-gray-600">
-              จำนวน: {fund.remaining_grant === null ? 'ไม่จำกัด' : `${fund.remaining_grant || 0}/${fund.max_grants === null ? 'ไม่จำกัด' : fund.max_grants} ทุน`}
-            </div>
-            {maxAmountPerGrant && (
-              <div className="text-xs text-green-600 font-medium">
-                สูงสุด/ทุน: {formatAmount(maxAmountPerGrant)}
-              </div>
-            )}
+          <div className="text-sm font-medium text-gray-900">
+            {formatAmount(remainingBudget)}
           </div>
+
+          {isWithinApplicationPeriod && remainingBudget === 0 ? (
+            <div className="text-xs text-red-600 mt-1">งบประมาณหมด</div>
+          ) : !isWithinApplicationPeriod ? (
+            <div className="text-xs text-gray-500 mt-1">ปิดรับคำขอ</div>
+          ) : null}
         </td>
-        <td className="px-6 py-4 whitespace-nowrap text-center">
-          {isAvailable ? (
+        <td className="px-6 py-4 text-center">
+          {isOnlineForm ? (
             <button
-              onClick={() => handleViewForm(fund)}
-              className={`inline-flex items-center gap-2 px-4 py-2 rounded-md text-sm font-medium transition-colors ${
-                hasOnlineForm
-                  ? 'bg-blue-600 text-white hover:bg-blue-700'
-                  : 'bg-green-600 text-white hover:bg-green-700'
-              }`}
+              onClick={() => handleViewDetails(fund)}
+              className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-blue-600 hover:text-blue-700"
+              title="เปิดดูรายละเอียดแบบฟอร์ม (อ่านอย่างเดียว)"
             >
-              {hasOnlineForm ? (
-                <>
-                  <Eye size={16} />
-                  ยื่นขอออนไลน์
-                </>
-              ) : (
-                <>
-                  <Download size={16} />
-                  ดาวน์โหลดฟอร์ม
-                </>
-              )}
+              <Search size={16} />
+              ดูรายละเอียด
             </button>
           ) : (
-            <span className="inline-flex items-center px-3 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-500">
-              ไม่เปิดรับสมัคร
-            </span>
+            <button
+              onClick={() => {
+                const docUrl = fund.form_url || "/documents/default-fund-form.docx";
+                window.open(docUrl, "_blank");
+              }}
+              className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-blue-600 hover:text-blue-700"
+              title="ดาวน์โหลดแบบฟอร์ม"
+            >
+              <Download size={16} />
+              ดาวน์โหลดฟอร์ม
+            </button>
           )}
         </td>
       </tr>
@@ -348,6 +598,21 @@ export default function PromotionFundContent({ onNavigate }) {
         { label: "ทุนอุดหนุนกิจกรรม" }
       ]}
     >
+      {/* Application Period Info */}
+      {renderApplicationPeriodInfo()}
+
+      <div className="mb-6 bg-gray-50 border border-gray-200 rounded-lg p-4">
+        <div className="flex items-start gap-3 text-gray-700">
+          <Info className="text-blue-500 mt-1" size={18} />
+          <div>
+            <p className="font-medium">โหมดผู้ดูแลระบบ</p>
+            <p className="text-sm text-gray-600">
+              หน้านี้ใช้สำหรับตรวจสอบข้อมูลทุนและแบบฟอร์มเท่านั้น ผู้ดูแลระบบไม่สามารถยื่นขอทุนผ่านหน้าแสดงผลนี้ได้
+            </p>
+          </div>
+        </div>
+      </div>
+
       {/* Control Bar */}
       <div className="mb-6 bg-white rounded-lg shadow-sm p-4">
         <div className="flex flex-col md:flex-row gap-4 items-center justify-between">
@@ -379,43 +644,55 @@ export default function PromotionFundContent({ onNavigate }) {
               <input
                 type="text"
                 placeholder="ค้นหาทุน..."
-                className="pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="text-gray-600 pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
                 value={searchTerm}
                 onChange={(e) => setSearchTerm(e.target.value)}
               />
             </div>
             
-            <button
-              onClick={() => setShowFilters(!showFilters)}
-              className="flex items-center gap-2 px-4 py-2 border border-gray-300 rounded-lg hover:bg-gray-50"
+            <select
+              className="px-4 py-2 text-gray-700 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white"
+              value={statusFilter}
+              onChange={(e) => setStatusFilter(e.target.value)}
             >
-              <Filter size={16} />
-              ตัวกรอง
-              <ChevronDown size={16} className={`transition-transform ${showFilters ? 'rotate-180' : ''}`} />
-            </button>
+              <option value="all">ทั้งหมด</option>
+              <option value="available">มีงบประมาณ</option>
+              <option value="unavailable">งบประมาณหมด</option>
+            </select>
           </div>
         </div>
+      </div>
 
-        {/* Filter Panel */}
-        {showFilters && (
-          <div className="mt-4 pt-4 border-t border-gray-200">
-            <div className="flex flex-wrap gap-4">
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">สถานะ:</label>
-                <select
-                  className="px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
-                  value={statusFilter}
-                  onChange={(e) => setStatusFilter(e.target.value)}
-                >
-                  <option value="all">ทั้งหมด</option>
-                  <option value="available">เปิดรับสมัคร</option>
-                  <option value="full">เต็มแล้ว</option>
-                </select>
-              </div>
+      {/* Summary Stats (Optional) */}
+      {filteredFunds.length > 0 && (
+        <div className="mb-4 grid grid-cols-3 gap-4">
+          <div className="bg-white p-4 rounded-lg shadow-sm">
+            <div className="text-sm text-gray-500">จำนวนทุนทั้งหมด</div>
+            <div className="text-2xl font-semibold text-gray-900">
+              {filteredFunds.reduce((sum, cat) => sum + (cat.subcategories?.length || 0), 0)}
             </div>
           </div>
-        )}
-      </div>
+          <div className="bg-white p-4 rounded-lg shadow-sm">
+            <div className="text-sm text-gray-500">ทุนที่มีงบประมาณ</div>
+            <div className="text-2xl font-semibold text-green-600">
+              {filteredFunds.reduce((sum, cat) => 
+                sum + (cat.subcategories?.filter(s => s.remaining_budget > 0).length || 0), 0
+              )}
+            </div>
+          </div>
+          <div className="bg-white p-4 rounded-lg shadow-sm">
+            <div className="text-sm text-gray-500">งบประมาณรวมคงเหลือ</div>
+            <div className="text-xl font-semibold text-blue-600">
+              {formatAmount(
+                filteredFunds.reduce((sum, cat) => 
+                  sum + (cat.subcategories?.reduce((subSum, sub) => 
+                    subSum + (sub.remaining_budget || 0), 0) || 0), 0
+                )
+              )}
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Funds Table */}
       {filteredFunds.length === 0 ? (
@@ -436,14 +713,14 @@ export default function PromotionFundContent({ onNavigate }) {
             <table className="min-w-full divide-y divide-gray-200">
               <thead className="bg-gray-50">
                 <tr>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-1/4">
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-2/5">
                     ชื่อทุน
                   </th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-2/5">
+                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-1/4">
                     เงื่อนไขทุน
                   </th>
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
-                    งบประมาณ / จำนวนทุน
+                    งบประมาณคงเหลือ
                   </th>
                   <th className="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
                     แบบฟอร์มขอทุน
@@ -452,15 +729,12 @@ export default function PromotionFundContent({ onNavigate }) {
               </thead>
               <tbody className="bg-white divide-y divide-gray-200">
                 {filteredFunds.map((category) => {
-                  // ถ้ามี subcategories ให้แสดงแต่ละรายการ
                   if (category.subcategories && category.subcategories.length > 0) {
                     return category.subcategories.map((fund) => {
-                      const isAvailable = fund.remaining_budget > 0 && 
-                                        (fund.remaining_grant === null || fund.remaining_grant === undefined || fund.remaining_grant > 0);
-                      return renderFundRow(fund, category, isAvailable);
+                      const isAvailable = fund.remaining_budget > 0;
+                      return renderFundRow(fund, isAvailable);
                     });
                   } else {
-                    // ถ้าไม่มี subcategories แสดงแถวว่างพร้อมข้อความ
                     return (
                       <tr key={category.category_id}>
                         <td colSpan="4" className="px-6 py-4 text-center text-gray-500">
@@ -479,45 +753,49 @@ export default function PromotionFundContent({ onNavigate }) {
       {/* Condition Modal */}
       {showConditionModal && (
         <div 
-          className="fixed inset-0 z-50 overflow-y-auto flex items-center justify-center min-h-screen px-4"
-          ref={modalRef} // Add ref to the outer div
-          tabIndex={-1} // Make the div focusable
-          onKeyDown={(e) => e.key === 'Escape' && setShowConditionModal(false)}
+          className="fixed inset-0 z-50 flex items-center justify-center p-4"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) {
+              setShowConditionModal(false);
+            }
+          }}
         >
-          {/* Backdrop */}
           <div
             className="fixed inset-0 bg-gray-500 opacity-75 transition-opacity duration-300 ease-in-out"
             onClick={() => setShowConditionModal(false)}
             aria-hidden="true"
           ></div>
 
-          {/* Modal panel */}
           <div 
-            className="relative bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all duration-300 ease-in-out max-w-lg w-full sm:my-8"
+            ref={modalRef}
+            className="relative bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all duration-300 ease-in-out max-w-2xl w-full max-h-[90vh] flex flex-col"
             role="dialog"
             aria-labelledby="modal-title"
             aria-describedby="modal-description"
+            tabIndex={-1}
           >
-            <div className="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
-              <div className="flex justify-between items-start mb-4">
-                <h3 className="text-lg leading-6 font-medium text-gray-900" id="modal-title">
+            <div className="bg-white px-4 pt-5 pb-4 sm:p-6 border-b border-gray-200 flex-shrink-0">
+              <div className="flex justify-between items-start">
+                <h3 className="text-lg leading-6 font-medium text-gray-900 pr-4" id="modal-title">
                   เงื่อนไขทุน: {selectedCondition.title}
                 </h3>
                 <button
                   type="button"
-                  className="text-gray-400 hover:text-gray-500"
+                  className="text-gray-400 hover:text-gray-500 flex-shrink-0"
                   onClick={() => setShowConditionModal(false)}
                 >
                   <X size={20} />
                 </button>
               </div>
-              <div className="mt-2">
-                <p className="text-sm text-gray-700 whitespace-pre-wrap" id="modal-description">
-                  {selectedCondition.content}
-                </p>
+            </div>
+            
+            <div className="flex-1 overflow-y-auto px-4 py-4 sm:px-6">
+              <div className="text-sm text-gray-700 whitespace-pre-wrap leading-relaxed" id="modal-description">
+                {selectedCondition.content}
               </div>
             </div>
-            <div className="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse">
+            
+            <div className="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse border-t border-gray-200 flex-shrink-0">
               <button
                 type="button"
                 className="w-full inline-flex justify-center rounded-md border border-transparent shadow-sm px-4 py-2 bg-blue-600 text-base font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 sm:ml-3 sm:w-auto sm:text-sm"


### PR DESCRIPTION
## Summary
- replace the admin promotion fund component with the updated member UI, including filters, metrics, and application window alerts
- ensure the admin experience only exposes read-only form access by removing submission actions and routing online forms in read-only mode
- add a notice banner and data fallbacks to make the listing resilient to varying API field names

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68e15d5f1638832abb241b7a8815bb44