### PR TITLE
Default member fund views to current fiscal year

### DIFF
--- a/frontend_project_fund/app/member/components/applications/ApplicationList.js
+++ b/frontend_project_fund/app/member/components/applications/ApplicationList.js
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import { Search, Filter, Eye, Download, FileText, ClipboardList, Plus } from "lucide-react";
 import { submissionAPI, teacherAPI } from "@/app/lib/member_api";
+import systemConfigAPI from "@/app/lib/system_config_api";
 import { statusService } from "@/app/lib/status_service";
 import { useStatusMap } from "@/app/hooks/useStatusMap";
 import StatusBadge from "../common/StatusBadge";
@@ -17,16 +18,79 @@ export default function ApplicationList({ onNavigate }) {
   const [searchTerm, setSearchTerm] = useState("");
   const [statusFilter, setStatusFilter] = useState("all");
   const [yearFilter, setYearFilter] = useState("all");
+  const [yearOptions, setYearOptions] = useState([]);
+  const [yearIdMap, setYearIdMap] = useState({});
+  const [defaultYear, setDefaultYear] = useState("all");
   const [loading, setLoading] = useState(false);
   const { statuses: statusOptions, getLabelById, isLoading: statusLoading } = useStatusMap();
-  
-  // Map display year to year_id used by API
-  const YEAR_ID_MAP = { "2566": 1, "2567": 2, "2568": 3 };
+
+  useEffect(() => {
+    const loadYearOptions = async () => {
+      try {
+        const [yearsData, currentYearRes] = await Promise.all([
+          fetch("/api/years")
+            .then((res) => {
+              if (!res.ok) throw new Error("Failed to load years");
+              return res.json();
+            })
+            .then((data) => {
+              if (data?.success) {
+                const list = data.years || data.data || [];
+                return list.filter((year) => year && year.year && year.year_id);
+              }
+              return [];
+            })
+            .catch((error) => {
+              console.error("Error fetching year options:", error);
+              return [];
+            }),
+          systemConfigAPI.getCurrentYear().catch((err) => {
+            console.warn("Failed to fetch current year for applications:", err);
+            return null;
+          }),
+        ]);
+
+        const sortedYears = yearsData
+          .map((year) => ({
+            year: String(year.year),
+            year_id: year.year_id,
+          }))
+          .filter((year) => year.year && year.year_id != null)
+          .sort((a, b) => Number(b.year) - Number(a.year));
+
+        const map = {};
+        const optionList = sortedYears.map((item) => {
+          map[item.year] = item.year_id;
+          return item.year;
+        });
+
+        setYearIdMap(map);
+        setYearOptions(optionList);
+
+        const resolvedYear = (() => {
+          if (currentYearRes?.current_year) return String(currentYearRes.current_year);
+          if (optionList.length > 0) return optionList[0];
+          return "";
+        })();
+
+        if (resolvedYear) {
+          setDefaultYear(resolvedYear);
+          setYearFilter((prev) => (prev === resolvedYear ? prev : resolvedYear));
+        } else {
+          setDefaultYear("all");
+        }
+      } catch (error) {
+        console.error("Error loading year options:", error);
+      }
+    };
+
+    loadYearOptions();
+  }, []);
 
   // Load applications on mount and when year filter changes
   useEffect(() => {
     loadApplications();
-  }, [yearFilter]);
+  }, [yearFilter, yearIdMap]);
 
   useEffect(() => {
     filterApplications();
@@ -39,8 +103,12 @@ export default function ApplicationList({ onNavigate }) {
       // Build query params for API
       const params = { limit: 100 };
       if (yearFilter !== "all") {
-        const yearId = YEAR_ID_MAP[yearFilter];
-        if (yearId) params.year_id = yearId;
+        const yearId = yearIdMap[yearFilter];
+        if (yearId) {
+          params.year_id = yearId;
+        } else {
+          params.year = yearFilter;
+        }
       }
 
       const [response, subRes] = await Promise.all([
@@ -369,9 +437,11 @@ export default function ApplicationList({ onNavigate }) {
             onChange={(e) => setYearFilter(e.target.value)}
           >
             <option value="all">ปีทั้งหมด</option>
-            <option value="2568">2568</option>
-            <option value="2567">2567</option>
-            <option value="2566">2566</option>
+            {yearOptions.map((year) => (
+              <option key={year} value={year}>
+                {year}
+              </option>
+            ))}
           </select>
         </div>
 
@@ -397,7 +467,7 @@ export default function ApplicationList({ onNavigate }) {
                   onClick={() => {
                     setSearchTerm('');
                     setStatusFilter('all');
-                    setYearFilter('all');
+                    setYearFilter(defaultYear !== 'all' ? defaultYear : 'all');
                   }}
                   className="btn btn-secondary"
                 >

--- a/frontend_project_fund/app/member/components/funds/PromotionFundContent.js
+++ b/frontend_project_fund/app/member/components/funds/PromotionFundContent.js
@@ -10,7 +10,7 @@ import { FORM_TYPE_CONFIG } from '../../../lib/form_type_config';
 import systemConfigAPI from '../../../lib/system_config_api';
 
 export default function PromotionFundContent({ onNavigate }) {
-  const [selectedYear, setSelectedYear] = useState("2568");
+  const [selectedYear, setSelectedYear] = useState("");
   const [fundCategories, setFundCategories] = useState([]);
   const [filteredFunds, setFilteredFunds] = useState([]);
   const [years, setYears] = useState([]);
@@ -91,15 +91,36 @@ export default function PromotionFundContent({ onNavigate }) {
       setLoading(true);
       setError(null);
 
-      const [roleInfo, yearsData, configData] = await Promise.all([
+      const [roleInfo, yearsData, configData, currentYearRes] = await Promise.all([
         targetRolesUtils.getCurrentUserRole(),
         loadAvailableYears(),
-        loadSystemConfig()
+        loadSystemConfig(),
+        systemConfigAPI.getCurrentYear().catch((err) => {
+          console.warn('Failed to fetch current year:', err);
+          return null;
+        }),
       ]);
 
       setUserRole(roleInfo);
       setYears(yearsData);
-      setSystemConfig(configData);
+      if (configData) {
+        setSystemConfig(configData);
+      }
+
+      const derivedYear = (() => {
+        if (currentYearRes?.current_year) return String(currentYearRes.current_year);
+        if (configData?.current_year) return String(configData.current_year);
+        if (Array.isArray(yearsData) && yearsData.length > 0) {
+          const first = yearsData[0];
+          if (first?.year) return String(first.year);
+          if (first?.year_id) return String(first.year_id);
+        }
+        return '';
+      })();
+
+      if (derivedYear) {
+        setSelectedYear(derivedYear);
+      }
 
       // funds will reload via selectedYear effect
     } catch (err) {
@@ -188,7 +209,14 @@ export default function PromotionFundContent({ onNavigate }) {
         now: win.now,
       });
 
-      return { start_date, end_date, is_open_effective: open };
+      return {
+        start_date,
+        end_date,
+        is_open_effective: open,
+        current_year: win.current_year ?? null,
+        last_updated: win.last_updated ?? null,
+        now: win.now ?? null,
+      };
     } catch (e) {
       console.warn('loadSystemConfig failed:', e);
       // อย่าบล็อกหน้า ถ้าโหลดไม่ได้ให้ถือว่าเปิดไว้ก่อน

--- a/frontend_project_fund/app/member/components/funds/ReceivedFundsList.js
+++ b/frontend_project_fund/app/member/components/funds/ReceivedFundsList.js
@@ -3,6 +3,7 @@
 import { useState, useEffect, useMemo } from "react";
 import { Search, Eye, Download, Gift } from "lucide-react";
 import { submissionAPI } from "@/app/lib/member_api";
+import systemConfigAPI from "../../../lib/system_config_api";
 import PageLayout from "../common/PageLayout";
 import Card from "../common/Card";
 import DataTable from "../common/DataTable";
@@ -13,6 +14,7 @@ export default function ReceivedFundsList({ onNavigate }) {
   const [funds, setFunds] = useState([]);
   const [searchTerm, setSearchTerm] = useState("");
   const [yearFilter, setYearFilter] = useState("all");
+  const [defaultYear, setDefaultYear] = useState("all");
   const [categoryFilter, setCategoryFilter] = useState("all");
   const [loading, setLoading] = useState(false);
   const [currentPage, setCurrentPage] = useState(1);
@@ -20,7 +22,21 @@ export default function ReceivedFundsList({ onNavigate }) {
 
   useEffect(() => {
     loadFunds();
+    fetchCurrentYear();
   }, []);
+
+  const fetchCurrentYear = async () => {
+    try {
+      const res = await systemConfigAPI.getCurrentYear();
+      if (res?.current_year) {
+        const yearString = String(res.current_year);
+        setDefaultYear(yearString);
+        setYearFilter(yearString);
+      }
+    } catch (err) {
+      console.warn("Failed to fetch current year for received funds:", err);
+    }
+  };
 
   const loadFunds = async () => {
     setLoading(true);
@@ -70,10 +86,15 @@ export default function ReceivedFundsList({ onNavigate }) {
   const yearOptions = useMemo(() => {
     const set = new Set();
     funds.forEach((f) => {
-      if (f.year && f.year !== "-") set.add(f.year);
+      if (f.year && f.year !== "-") set.add(String(f.year));
     });
-    return Array.from(set).sort().reverse();
-  }, [funds]);
+    if (defaultYear !== "all" && defaultYear) {
+      set.add(String(defaultYear));
+    }
+    return Array.from(set)
+      .filter((y) => y)
+      .sort((a, b) => Number(b) - Number(a));
+  }, [funds, defaultYear]);
 
   const categoryOptions = useMemo(() => {
     const set = new Set();

--- a/frontend_project_fund/app/member/components/funds/ResearchFundContent.js
+++ b/frontend_project_fund/app/member/components/funds/ResearchFundContent.js
@@ -19,10 +19,9 @@ import { teacherAPI } from "../../../lib/member_api";
 import { targetRolesUtils, filterFundsByRole } from "../../../lib/target_roles_utils";
 import { FORM_TYPE_CONFIG } from "../../../lib/form_type_config";
 import systemConfigAPI from "../../../lib/system_config_api";
-import apiClient from "../../../lib/api";
 
 export default function ResearchFundContent({ onNavigate }) {
-  const [selectedYear, setSelectedYear] = useState("2568");
+  const [selectedYear, setSelectedYear] = useState("");
   const [yearId, setYearId] = useState(null);
   const [fundCategories, setFundCategories] = useState([]);
   const [filteredFunds, setFilteredFunds] = useState([]);
@@ -116,18 +115,42 @@ export default function ResearchFundContent({ onNavigate }) {
         targetRolesUtils.getCurrentUserRole(),
         loadAvailableYears(),
         loadSystemConfig(),
-        apiClient.get("/system-config/current-year")
+        systemConfigAPI.getCurrentYear().catch((err) => {
+          console.warn("Failed to fetch current year:", err);
+          return null;
+        }),
       ]);
 
       setUserRole(roleInfo);
       setYears(yearsData);
-      setSystemConfig(winData);
+      if (winData) {
+        setSystemConfig(winData);
+      }
 
-      const currentYear = currentYearRes?.current_year
-        ? String(currentYearRes.current_year)
-        : selectedYear;
+      const derivedYear = (() => {
+        if (currentYearRes?.current_year) return String(currentYearRes.current_year);
+        if (winData?.current_year) return String(winData.current_year);
+        if (Array.isArray(yearsData) && yearsData.length > 0) {
+          const first = yearsData[0];
+          if (first?.year) return String(first.year);
+          if (first?.year_id) return String(first.year_id);
+        }
+        return "";
+      })();
 
-      setSelectedYear(currentYear);
+      if (derivedYear) {
+        setSelectedYear(derivedYear);
+        const matchedYear = Array.isArray(yearsData)
+          ? yearsData.find(
+              (y) =>
+                String(y.year) === derivedYear ||
+                (y.year_id != null && String(y.year_id) === derivedYear)
+            )
+          : null;
+        if (matchedYear?.year_id) {
+          setYearId(matchedYear.year_id);
+        }
+      }
       // loadFundData will be triggered by effect on selectedYear
     } catch (err) {
       console.error("Error loading initial data:", err);
@@ -198,7 +221,14 @@ export default function ResearchFundContent({ onNavigate }) {
         now: win.now,
       });
 
-      return { start_date, end_date, is_open_effective: open };
+      return {
+        start_date,
+        end_date,
+        is_open_effective: open,
+        current_year: win.current_year ?? null,
+        last_updated: win.last_updated ?? null,
+        now: win.now ?? null,
+      };
     } catch (e) {
       console.warn("loadSystemConfig failed:", e);
       setIsWithinApplicationPeriod(true);


### PR DESCRIPTION
## Summary
- load the system configuration current fiscal year when initializing the member research and promotion fund pages
- populate the My Applications year filter from /api/years and default it to the current fiscal year
- default the Received Funds year filter to the configured fiscal year and include it in the dropdown options

## Testing
- not run (interactive eslint prompt)


------
https://chatgpt.com/codex/tasks/task_e_68e178f86034832aa9667e8e8def350e