### PR TITLE
Ensure upload route handles duplicate filenames safely

### DIFF
--- a/fund-management-api/routes/routes.go
+++ b/fund-management-api/routes/routes.go
@@ -5,6 +5,7 @@ import (
 	"fund-management-api/controllers"
 	"fund-management-api/middleware"
 	"fund-management-api/monitor"
+	"fund-management-api/utils"
 	"log"
 	"net/http"
 	"net/url"
@@ -548,7 +549,19 @@ func RegisterUploadRoutes(rg *gin.RouterGroup) {
 			return
 		}
 
-		dst := fmt.Sprintf("./uploads/%s", file.Filename)
+		uploadRoot := os.Getenv("UPLOAD_PATH")
+		if uploadRoot == "" {
+			uploadRoot = "./uploads"
+		}
+
+		if err := utils.EnsureDirectoryExists(uploadRoot); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to prepare upload directory"})
+			return
+		}
+
+		safeFilename := utils.GenerateUniqueFilename(uploadRoot, file.Filename)
+		dst := filepath.Join(uploadRoot, safeFilename)
+
 		if err := c.SaveUploadedFile(file, dst); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save file"})
 			return
@@ -556,7 +569,11 @@ func RegisterUploadRoutes(rg *gin.RouterGroup) {
 
 		c.JSON(http.StatusOK, gin.H{
 			"message": "File uploaded successfully",
-			"url":     "/uploads/" + file.Filename,
+			"file": gin.H{
+				"original_name": file.Filename,
+				"stored_name":   safeFilename,
+				"url":           fmt.Sprintf("/uploads/%s", safeFilename),
+			},
 		})
 	})
 }


### PR DESCRIPTION
## Summary
- ensure the public upload endpoint prepares the upload directory and generates unique filenames to avoid overwriting files with the same name
- return metadata for the stored file so callers know the final filename

## Testing
- Not run (go test ./... hung in the container while attempting to download modules)


------
https://chatgpt.com/codex/tasks/task_e_68e23ecf0c00832a81f55810ae9918b4