### PR TITLE
Use backend publication options for subcategory resolution

### DIFF
--- a/frontend_project_fund/app/member/components/applications/PublicationRewardForm.js
+++ b/frontend_project_fund/app/member/components/applications/PublicationRewardForm.js
@@ -952,9 +952,9 @@ export default function PublicationRewardForm({ onNavigate, categoryId, yearId, 
               option.author_status === formData.author_status &&
               option.journal_quartile === formData.journal_quartile
             );
-            const resolvedSubcategoryId = fallbackOption?.subcategory_id ?? result?.subcategory_id ?? null;
-            const resolvedBudgetId = fallbackOption?.subcategory_budget_id ?? result?.subcategory_budget_id ?? null;
-            const resolvedRewardAmount = fallbackOption?.reward_amount ?? result?.reward_amount ?? 0;
+            const resolvedSubcategoryId = result?.subcategory_id ?? fallbackOption?.subcategory_id ?? null;
+            const resolvedBudgetId = result?.subcategory_budget_id ?? fallbackOption?.subcategory_budget_id ?? null;
+            const resolvedRewardAmount = result?.reward_amount ?? fallbackOption?.reward_amount ?? 0;
             setFormData(prev => ({
               ...prev,
               subcategory_id: resolvedSubcategoryId,


### PR DESCRIPTION
## Summary
- remove the hard-coded author-status to subcategory constants
- persist publication budget options returned by the backend and reuse them when the year changes
- resolve subcategory and budget identifiers from API responses with option fallbacks and submit the dynamic IDs

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e26eac180c832aa4d5844ef161f5be