### PR TITLE
feat: build dashboards from live API data

### DIFF
--- a/frontend_project_fund/app/admin/components/dashboard/BudgetSummary.js
+++ b/frontend_project_fund/app/admin/components/dashboard/BudgetSummary.js
@@ -4,26 +4,36 @@
 import { DollarSign, TrendingUp, TrendingDown, PieChart } from "lucide-react";
 
 export default function BudgetSummary({ budget }) {
+  const total = Number(budget?.total ?? budget?.total_budget ?? 0);
+  const used = Number(budget?.thisYear ?? budget?.used ?? budget?.used_budget ?? 0);
+  const remaining = Number.isFinite(Number(budget?.remaining))
+    ? Number(budget?.remaining)
+    : Math.max(total - used, 0);
+
+  const safeTotal = total >= 0 ? total : 0;
+  const safeUsed = used >= 0 ? used : 0;
+  const safeRemaining = remaining >= 0 ? remaining : 0;
+
   const formatCurrency = (amount) => {
-    return new Intl.NumberFormat('th-TH', {
-      style: 'currency',
-      currency: 'THB',
-      minimumFractionDigits: 0
-    }).format(amount);
+    return new Intl.NumberFormat("th-TH", {
+      style: "currency",
+      currency: "THB",
+      minimumFractionDigits: 0,
+    }).format(Number.isFinite(amount) ? amount : 0);
   };
 
-  const percentageUsed = budget.total > 0 
-    ? ((budget.thisYear / budget.total) * 100).toFixed(1)
+  const percentageUsed = safeTotal > 0
+    ? ((safeUsed / safeTotal) * 100).toFixed(1)
     : 0;
 
-  const percentageRemaining = budget.total > 0
-    ? ((budget.remaining / budget.total) * 100).toFixed(1)
+  const percentageRemaining = safeTotal > 0
+    ? ((safeRemaining / safeTotal) * 100).toFixed(1)
     : 0;
 
   const budgetItems = [
     {
       label: "งบประมาณที่ได้รับทั้งหมด",
-      value: formatCurrency(budget.total),
+      value: formatCurrency(safeTotal),
       icon: DollarSign,
       bgColor: "bg-gray-50",
       textColor: "text-gray-700",
@@ -31,7 +41,7 @@ export default function BudgetSummary({ budget }) {
     },
     {
       label: "ใช้ไปในปีนี้",
-      value: formatCurrency(budget.thisYear),
+      value: formatCurrency(safeUsed),
       icon: TrendingDown,
       bgColor: "bg-blue-50",
       textColor: "text-blue-700",
@@ -40,7 +50,7 @@ export default function BudgetSummary({ budget }) {
     },
     {
       label: "คงเหลือสำหรับปีนี้",
-      value: formatCurrency(budget.remaining),
+      value: formatCurrency(safeRemaining),
       icon: TrendingUp,
       bgColor: "bg-green-50",
       textColor: "text-green-700",

--- a/frontend_project_fund/app/admin/components/dashboard/DashboardContent.js
+++ b/frontend_project_fund/app/admin/components/dashboard/DashboardContent.js
@@ -1,108 +1,396 @@
-// dashboard/DashboardContent.js
 "use client";
 
-import { useState, useEffect } from "react";
-import { LayoutDashboard, TrendingUp } from "lucide-react";
-import { mockDashboardStats, mockApplications, mockUser } from "../data/mockData";
-import PageHeader from "../common/PageHeader";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  LayoutDashboard,
+  TrendingUp,
+  Users,
+  FileText,
+  Clock,
+  CircleDollarSign,
+  PieChart,
+  RefreshCcw,
+} from "lucide-react";
+
+import PageLayout from "../common/PageLayout";
 import Card from "../common/Card";
-import StatCard from "./StatCard";
-import RecentApplications from "./RecentApplications";
+import SimpleCard from "../common/SimpleCard";
 import MonthlyChart from "./MonthlyChart";
 import BudgetSummary from "./BudgetSummary";
-import SimpleCard from "../common/SimpleCard";
-import PageLayout from "../common/PageLayout";
+import adminAPI from "../../../lib/admin_api";
+import {
+  formatCurrency,
+  formatNumber,
+  formatThaiDateFromBEString,
+  formatThaiDateTime,
+  formatThaiMonthShort,
+} from "@/app/utils/format";
 
-export default function DashboardContent({ onNavigate }) {
-  const [stats, setStats] = useState(mockDashboardStats);
-  const [recentApplications, setRecentApplications] = useState([]);
-  const [user, setUser] = useState(mockUser);
-  const [loading, setLoading] = useState(true);
+const MAX_PENDING_DISPLAY = 5;
 
-  useEffect(() => {
-    // Simulate loading data
-    setTimeout(() => {
-      setStats(mockDashboardStats);
-      setRecentApplications(mockApplications.slice(0, 3));
-      setUser(mockUser);
-      setLoading(false);
-    }, 200);
-  }, []);
+function OverviewCards({ overview, currentDate, onNavigate }) {
+  const cards = useMemo(() => {
+    const totalApplications = Number(overview?.total_applications ?? 0);
+    const pending = Number(overview?.pending_count ?? 0);
+    const totalUsers = Number(overview?.total_users ?? 0);
+    const usedBudget = Number(overview?.used_budget ?? 0);
+    const totalBudget = Number(overview?.total_budget ?? 0);
 
-  if (loading) {
-    return (
-      <div className="flex justify-center items-center h-64">
-        <div className="text-center">
-          <div className="w-12 h-12 border-4 border-blue-200 border-t-blue-600 rounded-full animate-spin mx-auto mb-4"></div>
-          <p className="text-gray-600">กำลังโหลดข้อมูล...</p>
+    return [
+      {
+        label: "คำร้องทั้งหมด",
+        value: formatNumber(totalApplications),
+        icon: FileText,
+        gradient: "from-sky-500 to-blue-600",
+      },
+      {
+        label: "รอดำเนินการ",
+        value: formatNumber(pending),
+        icon: Clock,
+        gradient: "from-amber-400 to-orange-500",
+        onClick: () => onNavigate?.("applications-list"),
+      },
+      {
+        label: "ผู้ใช้งานทั้งหมด",
+        value: formatNumber(totalUsers),
+        icon: Users,
+        gradient: "from-fuchsia-500 to-pink-500",
+      },
+      {
+        label: "งบที่ใช้ไป",
+        value: formatCurrency(usedBudget),
+        icon: CircleDollarSign,
+        gradient: "from-emerald-500 to-green-600",
+      },
+      {
+        label: "งบประมาณประจำปี",
+        value: formatCurrency(totalBudget),
+        icon: PieChart,
+        gradient: "from-slate-500 to-gray-700",
+      },
+    ];
+  }, [overview, onNavigate]);
+
+  return (
+    <div className="space-y-4">
+      {currentDate && (
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 text-sm text-gray-600">
+          <span>
+            อัปเดตล่าสุด: <span className="font-medium text-gray-800">{currentDate}</span>
+          </span>
+          <span className="text-xs sm:text-sm text-gray-500">
+            ข้อมูลสรุปภาพรวมการใช้งานระบบประจำปีปัจจุบัน
+          </span>
         </div>
+      )}
+
+      <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-5 gap-4">
+        {cards.map((card, index) => {
+          const CardWrapper = card.onClick ? "button" : "div";
+          return (
+            <CardWrapper
+              key={card.label}
+              onClick={card.onClick}
+              className={`relative overflow-hidden rounded-xl bg-gradient-to-br ${card.gradient} text-white p-5 shadow-lg transition transform hover:scale-[1.02] focus:outline-none focus:ring-2 focus:ring-white/60 ${
+                card.onClick ? "cursor-pointer" : ""
+              }`}
+              type={card.onClick ? "button" : undefined}
+            >
+              <div className="relative z-10">
+                <div className="flex items-center justify-between">
+                  <div className="text-3xl font-bold">{card.value}</div>
+                  <card.icon className="w-10 h-10 opacity-80" />
+                </div>
+                <p className="mt-3 text-sm text-white/90">{card.label}</p>
+              </div>
+
+              <div className="absolute inset-0 opacity-20">
+                <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.6),_transparent)]" />
+              </div>
+            </CardWrapper>
+          );
+        })}
       </div>
-    );
+    </div>
+  );
+}
+
+function CategoryBudgetTable({ categories = [] }) {
+  if (!categories.length) {
+    return <p className="text-center text-gray-500 py-4">ไม่มีข้อมูลการใช้งบประมาณตามหมวดหมู่</p>;
   }
 
   return (
-    <div>
-      <PageLayout
-        title="แดชบอร์ด"
-        subtitle="ภาพรวมระบบและสถิติการใช้งาน"
-        icon={LayoutDashboard}
-        loading={loading}
-      />
+    <div className="overflow-x-auto">
+      <table className="min-w-full text-sm">
+        <thead>
+          <tr className="text-left text-gray-500">
+            <th className="py-2 pr-4 font-medium">หมวดหมู่ทุน</th>
+            <th className="py-2 px-4 font-medium text-center">จำนวนคำร้อง</th>
+            <th className="py-2 px-4 font-medium text-right">อนุมัติแล้ว</th>
+            <th className="py-2 px-4 font-medium text-right">งบที่จัดสรร</th>
+            <th className="py-2 pl-4 font-medium text-right">ใช้ไป (%)</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-100">
+          {categories.map((category) => {
+            const allocated = Number(category?.allocated_budget ?? 0);
+            const approved = Number(category?.approved_amount ?? 0);
+            const utilization = allocated > 0 ? Math.min((approved / allocated) * 100, 999) : 0;
 
-      {/* Announcements */}
-      <SimpleCard title="ประกาศล่าสุด" defaultCollapsed={true} className="mt-6 mb-6">
-        <div className="space-y-4">
-          <div className="bg-blue-50 border-l-4 border-blue-500 p-4 rounded">
-            <p className="font-semibold text-blue-900">ประกาศ</p>
-            <p className="text-blue-700">
-              เปิดรับสมัครทุนวิจัยประจำปี 2569 ตั้งแต่วันที่ 1 กรกฎาคม - 31 สิงหาคม 2568
-            </p>
-          </div>
-          <div className="bg-green-50 border-l-4 border-green-500 p-4 rounded">
-            <p className="font-semibold text-green-900">อัพเดท</p>
-            <p className="text-green-700">
-              ระบบได้รับการปรับปรุงใหม่ เพิ่มฟีเจอร์การติดตามสถานะคำร้องแบบ Real-time
-            </p>
-          </div>
-        </div>
-      </SimpleCard>
-
-      {/* Welcome Banner */}
-      <div className="bg-gradient-to-r from-blue-500 to-purple-600 text-white p-6 rounded-lg mb-8 shadow-lg">
-        <h2 className="text-2xl font-bold mb-2">
-          สวัสดี, {user.position}{user.user_fname} {user.user_lname}
-        </h2>
-        <p className="opacity-90">ยินดีต้อนรับเข้าสู่ระบบบริหารจัดการทุนวิจัย</p>
-      </div>
-      
-      {/* Statistics Cards */}
-      <StatCard stats={stats} />
-
-      {/* Charts Section */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
-        <SimpleCard title="สถิติการยื่นคำร้องรายเดือน" icon={TrendingUp}>
-          <MonthlyChart data={stats.monthlyStats} />
-        </SimpleCard>
-
-        <SimpleCard title="สรุปงบประมาณ">
-          <BudgetSummary budget={stats.budgetUsed} />
-        </SimpleCard>
-      </div>
-
-      {/* Recent Applications */}
-      <Card 
-        title="คำร้องล่าสุดของฉัน"
-        action={
-          <button 
-            onClick={() => onNavigate('applications')}
-            className="text-sm text-blue-600 hover:text-blue-700 transition-colors"
-          >
-            ดูทั้งหมด →
-          </button>
-        }
-      >
-        <RecentApplications applications={recentApplications} />
-      </Card>
+            return (
+              <tr key={category.category_name} className="text-gray-700">
+                <td className="py-3 pr-4">
+                  <p className="font-medium text-gray-900">{category.category_name}</p>
+                  <p className="text-xs text-gray-500">รวมทั้งหมวดหมู่</p>
+                </td>
+                <td className="py-3 px-4 text-center font-semibold text-gray-900">
+                  {formatNumber(category?.total_applications ?? 0)}
+                </td>
+                <td className="py-3 px-4 text-right text-blue-600 font-medium">
+                  {formatCurrency(approved)}
+                </td>
+                <td className="py-3 px-4 text-right text-gray-600">
+                  {formatCurrency(allocated)}
+                </td>
+                <td className="py-3 pl-4">
+                  <div className="flex flex-col items-end gap-1">
+                    <span className="text-sm font-semibold text-emerald-600">
+                      {utilization.toFixed(1)}%
+                    </span>
+                    <div className="w-24 h-2 bg-gray-200 rounded-full overflow-hidden">
+                      <div
+                        className="h-full bg-gradient-to-r from-emerald-400 to-emerald-600"
+                        style={{ width: `${Math.min(utilization, 100)}%` }}
+                      />
+                    </div>
+                  </div>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
     </div>
+  );
+}
+
+function PendingApplicationsList({ applications = [] }) {
+  if (!applications.length) {
+    return <p className="text-center text-gray-500 py-6">ไม่มีคำร้องที่รอดำเนินการ</p>;
+  }
+
+  return (
+    <div className="space-y-4">
+      {applications.slice(0, MAX_PENDING_DISPLAY).map((app) => {
+        const amount = formatCurrency(app?.requested_amount ?? app?.amount ?? 0);
+        const submittedAt = formatThaiDateTime(app?.submitted_at);
+        const key = app?.application_id ?? app?.submission_id ?? app?.application_number ?? submittedAt;
+
+        return (
+          <div
+            key={key}
+            className="border border-gray-200 rounded-lg p-4 hover:border-blue-400 transition-colors"
+          >
+            <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
+              <div>
+                <p className="font-semibold text-gray-900">
+                  {app?.project_title || app?.title || "-"}
+                </p>
+                <p className="text-xs text-gray-500">เลขที่คำร้อง: {app?.application_number || "-"}</p>
+                {app?.category_name && (
+                  <p className="text-xs text-gray-500 mt-1">หมวด: {app.category_name}</p>
+                )}
+              </div>
+              <div className="text-xs text-gray-500 whitespace-nowrap">{submittedAt}</div>
+            </div>
+
+            <div className="mt-3 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 text-sm text-gray-600">
+              <div>
+                <p className="font-medium text-gray-700">{app?.applicant_name || "ไม่ระบุผู้ยื่น"}</p>
+                {app?.subcategory_name && (
+                  <p className="text-xs text-gray-500">{app.subcategory_name}</p>
+                )}
+              </div>
+              <div className="text-right">
+                <p className="text-sm font-semibold text-blue-600">{amount}</p>
+                <p className="text-xs text-gray-500">วงเงินที่ขอ</p>
+              </div>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function ErrorState({ message, onRetry }) {
+  return (
+    <div className="bg-red-50 border border-red-200 text-red-700 p-6 rounded-lg">
+      <p className="font-semibold mb-2">เกิดข้อผิดพลาดในการโหลดข้อมูลแดชบอร์ด</p>
+      <p className="text-sm mb-4">{message}</p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="inline-flex items-center gap-2 rounded-lg bg-red-600 text-white px-4 py-2 text-sm hover:bg-red-700 transition"
+      >
+        <RefreshCcw className="w-4 h-4" />
+        ลองอีกครั้ง
+      </button>
+    </div>
+  );
+}
+
+export default function DashboardContent({ onNavigate }) {
+  const [stats, setStats] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  const loadDashboard = useCallback(async ({ silent = false } = {}) => {
+    if (silent) {
+      setIsRefreshing(true);
+    } else {
+      setLoading(true);
+    }
+    setError(null);
+
+    try {
+      const response = await adminAPI.getSystemStats();
+      const payload = response?.stats || response;
+      setStats(payload || {});
+    } catch (err) {
+      console.error("Error fetching admin dashboard stats:", err);
+      setError(err?.message || "ไม่สามารถโหลดข้อมูลได้ในขณะนี้");
+    } finally {
+      if (silent) {
+        setIsRefreshing(false);
+      } else {
+        setLoading(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    loadDashboard();
+  }, [loadDashboard]);
+
+  const overview = stats?.overview ?? {};
+  const categoryBudgets = useMemo(
+    () => (Array.isArray(stats?.category_budgets) ? stats.category_budgets : []),
+    [stats]
+  );
+  const pendingApplications = useMemo(
+    () => (Array.isArray(stats?.pending_applications) ? stats.pending_applications : []),
+    [stats]
+  );
+
+  const monthlyStats = useMemo(() => {
+    const trends = Array.isArray(stats?.monthly_trends) ? stats.monthly_trends : [];
+    const recent = trends.slice(-6);
+    return recent.map((item) => ({
+      month: formatThaiMonthShort(item?.month ?? ""),
+      applications: Number(item?.total_applications ?? item?.applications ?? 0),
+      approved: Number(item?.approved ?? 0),
+    }));
+  }, [stats]);
+
+  const budgetOverview = useMemo(() => {
+    const total = Number(overview?.total_budget ?? 0);
+    const used = Number(overview?.used_budget ?? 0);
+    const remaining = Math.max(total - used, 0);
+
+    return {
+      total,
+      thisYear: used,
+      remaining,
+    };
+  }, [overview]);
+
+  const currentDate = stats?.current_date
+    ? formatThaiDateFromBEString(stats.current_date)
+    : null;
+
+  const handleRefresh = () => loadDashboard({ silent: true });
+
+  return (
+    <PageLayout
+      title="แดชบอร์ดผู้ดูแลระบบ"
+      subtitle="ภาพรวมการดำเนินงานและการใช้งบประมาณของระบบ"
+      icon={LayoutDashboard}
+      loading={loading}
+      actions={(
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={() => onNavigate?.("applications-list")}
+            className="inline-flex items-center gap-2 rounded-lg border border-blue-600 px-3 py-2 text-sm font-medium text-blue-600 hover:bg-blue-50 transition"
+          >
+            จัดการคำร้อง
+          </button>
+          <button
+            type="button"
+            onClick={handleRefresh}
+            disabled={isRefreshing}
+            className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700 transition disabled:opacity-60"
+          >
+            <RefreshCcw className={`w-4 h-4 ${isRefreshing ? "animate-spin" : ""}`} />
+            {isRefreshing ? "กำลังรีเฟรช..." : "รีเฟรช"}
+          </button>
+        </div>
+      )}
+    >
+      {error ? (
+        <ErrorState message={error} onRetry={handleRefresh} />
+      ) : (
+        <div className="space-y-8">
+          <OverviewCards overview={overview} currentDate={currentDate} onNavigate={onNavigate} />
+
+          <div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
+            <SimpleCard title="แนวโน้มการยื่นคำร้อง" icon={TrendingUp}>
+              <MonthlyChart data={monthlyStats} />
+            </SimpleCard>
+
+            <SimpleCard title="สรุปการใช้งบประมาณ" icon={PieChart}>
+              <BudgetSummary budget={budgetOverview} />
+            </SimpleCard>
+
+            <SimpleCard
+              title="หมวดหมู่การใช้งบสูงสุด"
+              icon={CircleDollarSign}
+              action={(
+                <button
+                  type="button"
+                  onClick={() => onNavigate?.("fund-settings")}
+                  className="text-sm text-blue-600 hover:text-blue-700"
+                >
+                  จัดการงบประมาณ →
+                </button>
+              )}
+            >
+              <CategoryBudgetTable categories={categoryBudgets.slice(0, 5)} />
+            </SimpleCard>
+          </div>
+
+          <Card
+            title="คำร้องที่รอดำเนินการ"
+            collapsible={false}
+            action={
+              pendingApplications.length > MAX_PENDING_DISPLAY && (
+                <button
+                  type="button"
+                  onClick={() => onNavigate?.("applications-list")}
+                  className="text-sm text-blue-600 hover:text-blue-700"
+                >
+                  ดูทั้งหมด {formatNumber(pendingApplications.length)} รายการ →
+                </button>
+              )
+            }
+          >
+            <PendingApplicationsList applications={pendingApplications} />
+          </Card>
+        </div>
+      )}
+    </PageLayout>
   );
 }

--- a/frontend_project_fund/app/admin/components/dashboard/MonthlyChart.js
+++ b/frontend_project_fund/app/admin/components/dashboard/MonthlyChart.js
@@ -3,15 +3,21 @@
 
 import { BarChart3, TrendingUp } from "lucide-react";
 
-export default function MonthlyChart({ data }) {
-  // Find max value for scaling
-  const maxValue = Math.max(...data.map(d => d.applications));
+export default function MonthlyChart({ data = [] }) {
+  const normalizedData = (Array.isArray(data) ? data : []).map((item) => ({
+    month: item?.month ?? "",
+    applications: Number(item?.applications ?? item?.total_applications ?? 0),
+    approved: Number(item?.approved ?? 0),
+  }));
+
+  const maxValue = normalizedData.length > 0
+    ? Math.max(...normalizedData.map((d) => d.applications))
+    : 0;
   const scale = maxValue > 0 ? 200 / maxValue : 1;
 
-  // Calculate statistics
-  const totalApplications = data.reduce((sum, item) => sum + item.applications, 0);
-  const totalApproved = data.reduce((sum, item) => sum + item.approved, 0);
-  const approvalRate = totalApplications > 0 
+  const totalApplications = normalizedData.reduce((sum, item) => sum + item.applications, 0);
+  const totalApproved = normalizedData.reduce((sum, item) => sum + item.approved, 0);
+  const approvalRate = totalApplications > 0
     ? ((totalApproved / totalApplications) * 100).toFixed(1)
     : 0;
 
@@ -36,7 +42,7 @@ export default function MonthlyChart({ data }) {
       {/* Bar Chart */}
       <div className="relative h-64">
         <div className="absolute inset-0 flex items-end justify-around px-2">
-          {data.map((stat, index) => (
+          {normalizedData.map((stat, index) => (
             <div key={index} className="flex flex-col items-center flex-1 mx-1">
               {/* Values on top of bars */}
               <div className="mb-2 text-center">

--- a/frontend_project_fund/app/admin/components/dashboard/RecentApplications.js
+++ b/frontend_project_fund/app/admin/components/dashboard/RecentApplications.js
@@ -1,36 +1,61 @@
 // dashboard/RecentApplications.js
 import StatusBadge from "../../../member/components/common/StatusBadge";
 
+const formatAmount = (value) => {
+  const amount = Number(value);
+  if (Number.isNaN(amount)) {
+    return "฿0";
+  }
+  return `฿${amount.toLocaleString("th-TH", { maximumFractionDigits: 0 })}`;
+};
+
 export default function RecentApplications({ applications = [] }) {
+  const items = Array.isArray(applications) ? applications : [];
+
+  if (items.length === 0) {
+    return <p className="text-center text-gray-500 py-8">ไม่มีคำร้องล่าสุด</p>;
+  }
+
   return (
     <div className="space-y-4">
-      {applications.length === 0 ? (
-        <p className="text-center text-gray-500 py-8">ไม่มีคำร้องล่าสุด</p>
-      ) : (
-        applications.map((app) => (
-          <div key={app.application_id} className="border rounded-lg p-4 hover:shadow-md transition-shadow">
-            <div className="flex justify-between items-start mb-2">
-              <div className="flex-1">
-                <h4 className="font-semibold text-gray-800">{app.project_title}</h4>
-                <p className="text-sm text-gray-600">เลขที่: {app.application_number}</p>
+      {items.map((app) => {
+        const key =
+          app.application_id ??
+          app.submission_id ??
+          app.application_number ??
+          `${app.project_title}-${app.submitted_at}`;
+
+        return (
+          <div key={key} className="border rounded-lg p-4 hover:shadow-md transition-shadow">
+            <div className="flex justify-between items-start mb-2 gap-4">
+              <div className="flex-1 min-w-0">
+                <h4 className="font-semibold text-gray-800 truncate">
+                  {app.project_title || app.title || "-"}
+                </h4>
+                <p className="text-sm text-gray-600">
+                  เลขที่: {app.application_number || app.submission_number || "-"}
+                </p>
               </div>
               <StatusBadge
                 statusId={
                   app.status_id ??
                   app.application_status_id ??
                   app.statusId ??
-                  app._original?.status_id
+                  app._original?.status_id ??
+                  app.status
                 }
                 fallbackLabel={app.status}
               />
             </div>
-            <div className="flex justify-between text-sm text-gray-600">
-              <span>{app.subcategory_name}</span>
-              <span>฿{app.requested_amount.toLocaleString()}</span>
+            <div className="flex justify-between text-sm text-gray-600 gap-4">
+              <span className="truncate">
+                {app.subcategory_name || app.category_name || "ไม่ระบุหมวดหมู่"}
+              </span>
+              <span className="font-semibold text-blue-600">{formatAmount(app.requested_amount ?? app.amount)}</span>
             </div>
           </div>
-        ))
-      )}
+        );
+      })}
     </div>
   );
 }

--- a/frontend_project_fund/app/member/components/dashboard/BudgetSummary.js
+++ b/frontend_project_fund/app/member/components/dashboard/BudgetSummary.js
@@ -4,26 +4,36 @@
 import { DollarSign, TrendingUp, TrendingDown, PieChart } from "lucide-react";
 
 export default function BudgetSummary({ budget }) {
+  const total = Number(budget?.total ?? budget?.total_budget ?? 0);
+  const used = Number(budget?.thisYear ?? budget?.used ?? budget?.used_budget ?? 0);
+  const remaining = Number.isFinite(Number(budget?.remaining))
+    ? Number(budget?.remaining)
+    : Math.max(total - used, 0);
+
+  const safeTotal = total >= 0 ? total : 0;
+  const safeUsed = used >= 0 ? used : 0;
+  const safeRemaining = remaining >= 0 ? remaining : 0;
+
   const formatCurrency = (amount) => {
-    return new Intl.NumberFormat('th-TH', {
-      style: 'currency',
-      currency: 'THB',
-      minimumFractionDigits: 0
-    }).format(amount);
+    return new Intl.NumberFormat("th-TH", {
+      style: "currency",
+      currency: "THB",
+      minimumFractionDigits: 0,
+    }).format(Number.isFinite(amount) ? amount : 0);
   };
 
-  const percentageUsed = budget.total > 0 
-    ? ((budget.thisYear / budget.total) * 100).toFixed(1)
+  const percentageUsed = safeTotal > 0
+    ? ((safeUsed / safeTotal) * 100).toFixed(1)
     : 0;
 
-  const percentageRemaining = budget.total > 0
-    ? ((budget.remaining / budget.total) * 100).toFixed(1)
+  const percentageRemaining = safeTotal > 0
+    ? ((safeRemaining / safeTotal) * 100).toFixed(1)
     : 0;
 
   const budgetItems = [
     {
       label: "งบประมาณที่ขอทั้งหมด",
-      value: formatCurrency(budget.total),
+      value: formatCurrency(safeTotal),
       icon: DollarSign,
       bgColor: "bg-gray-50",
       textColor: "text-gray-700",
@@ -31,7 +41,7 @@ export default function BudgetSummary({ budget }) {
     },
     {
       label: "ใช้ไปในปีนี้",
-      value: formatCurrency(budget.thisYear),
+      value: formatCurrency(safeUsed),
       icon: TrendingDown,
       bgColor: "bg-blue-50",
       textColor: "text-blue-700",
@@ -40,7 +50,7 @@ export default function BudgetSummary({ budget }) {
     },
     {
       label: "คงเหลือสำหรับปีนี้",
-      value: formatCurrency(budget.remaining),
+      value: formatCurrency(safeRemaining),
       icon: TrendingUp,
       bgColor: "bg-green-50",
       textColor: "text-green-700",

--- a/frontend_project_fund/app/member/components/dashboard/DashboardContent.js
+++ b/frontend_project_fund/app/member/components/dashboard/DashboardContent.js
@@ -1,108 +1,295 @@
-// dashboard/DashboardContent.js
 "use client";
 
-import { useState, useEffect } from "react";
-import { LayoutDashboard, TrendingUp } from "lucide-react";
-import { mockDashboardStats, mockApplications, mockUser } from "../data/mockData";
-import PageHeader from "../common/PageHeader";
+import { useCallback, useEffect, useState } from "react";
+import {
+  LayoutDashboard,
+  TrendingUp,
+  RefreshCcw,
+  CalendarDays,
+  BarChart3,
+} from "lucide-react";
+
+import PageLayout from "../common/PageLayout";
 import Card from "../common/Card";
+import SimpleCard from "../common/SimpleCard";
 import StatCard from "./StatCard";
-import RecentApplications from "./RecentApplications";
 import MonthlyChart from "./MonthlyChart";
 import BudgetSummary from "./BudgetSummary";
-import SimpleCard from "../common/SimpleCard";
-import PageLayout from "../common/PageLayout";
+import RecentApplications from "./RecentApplications";
+import { dashboardAPI, apiClient } from "../../../lib/api";
+import {
+  formatCurrency,
+  formatNumber,
+  formatThaiDateFromBEString,
+  formatThaiMonthShort,
+} from "@/app/utils/format";
 
-export default function DashboardContent({ onNavigate }) {
-  const [stats, setStats] = useState(mockDashboardStats);
-  const [recentApplications, setRecentApplications] = useState([]);
-  const [user, setUser] = useState(mockUser);
-  const [loading, setLoading] = useState(true);
+const normalizeDashboardStats = (apiStats = {}) => {
+  const myApplications = apiStats?.my_applications ?? {};
+  const budgetSummary = apiStats?.budget_summary ?? {};
+  const budgetUsage = apiStats?.budget_usage ?? {};
+  const monthlyStats = Array.isArray(apiStats?.monthly_stats)
+    ? apiStats.monthly_stats
+    : [];
+  const recentApplications = Array.isArray(apiStats?.recent_applications)
+    ? apiStats.recent_applications
+    : [];
 
-  useEffect(() => {
-    // Simulate loading data
-    setTimeout(() => {
-      setStats(mockDashboardStats);
-      setRecentApplications(mockApplications.slice(0, 3));
-      setUser(mockUser);
-      setLoading(false);
-    }, 200);
-  }, []);
+  const normalizedMonthly = monthlyStats.map((item) => ({
+    month: formatThaiMonthShort(item?.month ?? ""),
+    applications: Number(item?.applications ?? item?.total_applications ?? 0),
+    approved: Number(item?.approved ?? 0),
+  }));
 
-  if (loading) {
-    return (
-      <div className="flex justify-center items-center h-64">
-        <div className="text-center">
-          <div className="w-12 h-12 border-4 border-blue-200 border-t-blue-600 rounded-full animate-spin mx-auto mb-4"></div>
-          <p className="text-gray-600">กำลังโหลดข้อมูล...</p>
-        </div>
-      </div>
-    );
-  }
+  return {
+    myApplications: {
+      total: Number(myApplications?.total ?? 0),
+      pending: Number(myApplications?.pending ?? 0),
+      approved: Number(myApplications?.approved ?? 0),
+      rejected: Number(myApplications?.rejected ?? 0),
+      revision: Number(myApplications?.revision ?? 0),
+      draft: Number(myApplications?.draft ?? 0),
+      total_requested: Number(myApplications?.total_amount ?? myApplications?.total_requested ?? 0),
+      total_approved: Number(myApplications?.approved_amount ?? myApplications?.total_approved ?? 0),
+    },
+    budgetUsed: {
+      total: Number(budgetSummary?.total_requested ?? 0),
+      thisYear: Number(budgetSummary?.total_approved ?? 0),
+      remaining: Number(budgetSummary?.remaining ?? budgetUsage?.remaining_budget ?? 0),
+    },
+    monthlyStats: normalizedMonthly,
+    recentApplications: recentApplications.map((item) => ({
+      application_id: item?.submission_id ?? item?.application_id,
+      application_number: item?.submission_number ?? item?.application_number,
+      project_title: item?.title ?? item?.project_title,
+      requested_amount: Number(item?.amount ?? item?.requested_amount ?? 0),
+      subcategory_name: item?.subcategory_name ?? item?.category_name ?? "-",
+      status_id: item?.status_id ?? item?.application_status_id ?? item?.status,
+      status: item?.status_name ?? item?.status,
+      submitted_at: item?.submitted_at ?? item?.created_at ?? null,
+    })),
+    budgetUsage: {
+      yearBudget: Number(budgetUsage?.year_budget ?? 0),
+      usedBudget: Number(budgetUsage?.used_budget ?? 0),
+      remainingBudget: Number(budgetUsage?.remaining_budget ?? 0),
+    },
+    currentDate: apiStats?.current_date ?? null,
+  };
+};
+
+function WelcomeBanner({ user, stats }) {
+  const firstName = user?.user_fname ?? "";
+  const lastName = user?.user_lname ?? "";
+  const position = user?.position ?? "";
+  const totalApplications = formatNumber(stats?.myApplications?.total ?? 0);
+  const pending = formatNumber(stats?.myApplications?.pending ?? 0);
+  const approvedAmount = formatCurrency(stats?.myApplications?.total_approved ?? 0);
 
   return (
-    <div>
-      <PageLayout
-        title="แดชบอร์ด"
-        subtitle="ภาพรวมระบบและสถิติการใช้งาน"
-        icon={LayoutDashboard}
-        loading={loading}
-      />
-
-      {/* Announcements */}
-      <SimpleCard title="ประกาศล่าสุด" defaultCollapsed={true} className="mt-6 mb-6">
-        <div className="space-y-4">
-          <div className="bg-blue-50 border-l-4 border-blue-500 p-4 rounded">
-            <p className="font-semibold text-blue-900">ประกาศ</p>
-            <p className="text-blue-700">
-              เปิดรับสมัครทุนวิจัยประจำปี 2569 ตั้งแต่วันที่ 1 กรกฎาคม - 31 สิงหาคม 2568
-            </p>
+    <div className="bg-gradient-to-r from-blue-500 via-indigo-500 to-purple-600 text-white p-6 rounded-lg shadow-lg">
+      <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
+        <div>
+          <h2 className="text-2xl font-semibold">สวัสดี{position ? ` ${position}` : ""} {firstName} {lastName}</h2>
+          <p className="text-sm text-white/80 mt-1">
+            นี่คือภาพรวมการยื่นคำร้องของคุณประจำปีการเงินปัจจุบัน
+          </p>
+        </div>
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 text-sm">
+          <div className="bg-white/15 rounded-lg px-4 py-3">
+            <p className="text-white/80">คำร้องทั้งหมด</p>
+            <p className="text-xl font-bold">{totalApplications}</p>
           </div>
-          <div className="bg-green-50 border-l-4 border-green-500 p-4 rounded">
-            <p className="font-semibold text-green-900">อัพเดท</p>
-            <p className="text-green-700">
-              ระบบได้รับการปรับปรุงใหม่ เพิ่มฟีเจอร์การติดตามสถานะคำร้องแบบ Real-time
-            </p>
+          <div className="bg-white/15 rounded-lg px-4 py-3">
+            <p className="text-white/80">รอดำเนินการ</p>
+            <p className="text-xl font-bold">{pending}</p>
+          </div>
+          <div className="bg-white/15 rounded-lg px-4 py-3">
+            <p className="text-white/80">อนุมัติแล้ว (บาท)</p>
+            <p className="text-xl font-bold">{approvedAmount}</p>
           </div>
         </div>
-      </SimpleCard>
-
-      {/* Welcome Banner */}
-      <div className="bg-gradient-to-r from-blue-500 to-purple-600 text-white p-6 rounded-lg mb-8 shadow-lg">
-        <h2 className="text-2xl font-bold mb-2">
-          สวัสดี, {user.position}{user.user_fname} {user.user_lname}
-        </h2>
-        <p className="opacity-90">ยินดีต้อนรับเข้าสู่ระบบบริหารจัดการทุนวิจัย</p>
       </div>
-      
-      {/* Statistics Cards */}
-      <StatCard stats={stats} />
-
-      {/* Charts Section */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
-        <SimpleCard title="สถิติการยื่นคำร้องรายเดือน" icon={TrendingUp}>
-          <MonthlyChart data={stats.monthlyStats} />
-        </SimpleCard>
-
-        <SimpleCard title="สรุปงบประมาณ">
-          <BudgetSummary budget={stats.budgetUsed} />
-        </SimpleCard>
-      </div>
-
-      {/* Recent Applications */}
-      <Card 
-        title="คำร้องล่าสุดของฉัน"
-        action={
-          <button 
-            onClick={() => onNavigate('applications')}
-            className="text-sm text-blue-600 hover:text-blue-700 transition-colors"
-          >
-            ดูทั้งหมด →
-          </button>
-        }
-      >
-        <RecentApplications applications={recentApplications} />
-      </Card>
     </div>
+  );
+}
+
+function BudgetUsageHighlights({ usage }) {
+  const total = Number(usage?.yearBudget ?? 0);
+  const used = Number(usage?.usedBudget ?? 0);
+  const remaining = Math.max(Number(usage?.remainingBudget ?? total - used), 0);
+  const usedPercent = total > 0 ? Math.min((used / total) * 100, 100) : 0;
+
+  const items = [
+    { label: "งบประมาณประจำปี", value: formatCurrency(total), accent: "text-gray-800" },
+    { label: "ใช้ไปแล้ว", value: formatCurrency(used), accent: "text-blue-600" },
+    { label: "คงเหลือ", value: formatCurrency(remaining), accent: "text-emerald-600" },
+  ];
+
+  return (
+    <div className="space-y-3">
+      {items.map((item) => (
+        <div key={item.label} className="flex items-center justify-between text-sm">
+          <span className="text-gray-600">{item.label}</span>
+          <span className={`font-semibold ${item.accent}`}>{item.value}</span>
+        </div>
+      ))}
+
+      <div className="mt-4">
+        <div className="flex items-center justify-between text-xs text-gray-500 mb-1">
+          <span>การใช้จ่าย</span>
+          <span>{usedPercent.toFixed(1)}%</span>
+        </div>
+        <div className="w-full h-2 bg-gray-200 rounded-full overflow-hidden">
+          <div
+            className="h-full bg-gradient-to-r from-blue-500 to-indigo-600"
+            style={{ width: `${usedPercent}%` }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ErrorState({ message, onRetry }) {
+  return (
+    <div className="bg-red-50 border border-red-200 text-red-700 p-6 rounded-lg">
+      <p className="font-semibold mb-2">เกิดข้อผิดพลาดในการโหลดข้อมูลแดชบอร์ด</p>
+      <p className="text-sm mb-4">{message}</p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="inline-flex items-center gap-2 rounded-lg bg-red-600 text-white px-4 py-2 text-sm hover:bg-red-700 transition"
+      >
+        <RefreshCcw className="w-4 h-4" />
+        ลองอีกครั้ง
+      </button>
+    </div>
+  );
+}
+
+export default function DashboardContent({ onNavigate }) {
+  const [stats, setStats] = useState(null);
+  const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  const loadDashboard = useCallback(async ({ silent = false } = {}) => {
+    if (silent) {
+      setIsRefreshing(true);
+    } else {
+      setLoading(true);
+    }
+    setError(null);
+
+    try {
+      const response = await dashboardAPI.getStats();
+      const payload = response?.stats || response;
+      setStats(normalizeDashboardStats(payload || {}));
+    } catch (err) {
+      console.error("Error fetching dashboard stats:", err);
+      setError(err?.message || "ไม่สามารถโหลดข้อมูลได้ในขณะนี้");
+    } finally {
+      if (silent) {
+        setIsRefreshing(false);
+      } else {
+        setLoading(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    loadDashboard();
+  }, [loadDashboard]);
+
+  useEffect(() => {
+    setUser(apiClient.getUser());
+  }, []);
+
+  const currentDateLabel = stats?.currentDate
+    ? formatThaiDateFromBEString(stats.currentDate)
+    : null;
+
+  const handleRefresh = () => loadDashboard({ silent: true });
+
+  return (
+    <PageLayout
+      title="แดชบอร์ดของฉัน"
+      subtitle="ติดตามสถานะคำร้องและการใช้งบประมาณส่วนบุคคล"
+      icon={LayoutDashboard}
+      loading={loading}
+      actions={(
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={() => onNavigate?.("applications")}
+            className="inline-flex items-center gap-2 rounded-lg border border-blue-600 px-3 py-2 text-sm font-medium text-blue-600 hover:bg-blue-50 transition"
+          >
+            จัดการคำร้องของฉัน
+          </button>
+          <button
+            type="button"
+            onClick={handleRefresh}
+            disabled={isRefreshing}
+            className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700 transition disabled:opacity-60"
+          >
+            <RefreshCcw className={`w-4 h-4 ${isRefreshing ? "animate-spin" : ""}`} />
+            {isRefreshing ? "กำลังรีเฟรช..." : "รีเฟรช"}
+          </button>
+        </div>
+      )}
+    >
+      {error ? (
+        <ErrorState message={error} onRetry={handleRefresh} />
+      ) : stats ? (
+        <div className="space-y-8">
+          <WelcomeBanner user={user} stats={stats} />
+
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 text-sm text-gray-600">
+            <div className="flex items-center gap-2">
+              <CalendarDays className="w-4 h-4" />
+              <span>
+                อัปเดตล่าสุด: {currentDateLabel || "-"}
+              </span>
+            </div>
+            <div className="flex items-center gap-2 text-gray-500 text-xs sm:text-sm">
+              <BarChart3 className="w-4 h-4" />
+              <span>ข้อมูลสถิติคำนวณจากคำร้องและงบประมาณในระบบ</span>
+            </div>
+          </div>
+
+          <StatCard stats={stats} />
+
+          <div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
+            <SimpleCard title="แนวโน้มการยื่นคำร้อง" icon={TrendingUp}>
+              <MonthlyChart data={stats.monthlyStats} />
+            </SimpleCard>
+
+            <SimpleCard title="สรุปงบประมาณของฉัน">
+              <BudgetSummary budget={stats.budgetUsed} />
+            </SimpleCard>
+
+            <SimpleCard title="สถานะการใช้งบประมาณ" icon={CalendarDays}>
+              <BudgetUsageHighlights usage={stats.budgetUsage} />
+            </SimpleCard>
+          </div>
+
+          <Card
+            title="คำร้องล่าสุดของฉัน"
+            action={
+              <button
+                type="button"
+                onClick={() => onNavigate?.("applications")}
+                className="text-sm text-blue-600 hover:text-blue-700"
+              >
+                ดูทั้งหมด →
+              </button>
+            }
+          >
+            <RecentApplications applications={stats.recentApplications} />
+          </Card>
+        </div>
+      ) : null}
+    </PageLayout>
   );
 }

--- a/frontend_project_fund/app/member/components/dashboard/MonthlyChart.js
+++ b/frontend_project_fund/app/member/components/dashboard/MonthlyChart.js
@@ -3,15 +3,21 @@
 
 import { BarChart3, TrendingUp } from "lucide-react";
 
-export default function MonthlyChart({ data }) {
-  // Find max value for scaling
-  const maxValue = Math.max(...data.map(d => d.applications));
+export default function MonthlyChart({ data = [] }) {
+  const normalizedData = (Array.isArray(data) ? data : []).map((item) => ({
+    month: item?.month ?? "",
+    applications: Number(item?.applications ?? item?.total_applications ?? 0),
+    approved: Number(item?.approved ?? 0),
+  }));
+
+  const maxValue = normalizedData.length > 0
+    ? Math.max(...normalizedData.map((d) => d.applications))
+    : 0;
   const scale = maxValue > 0 ? 200 / maxValue : 1;
 
-  // Calculate statistics
-  const totalApplications = data.reduce((sum, item) => sum + item.applications, 0);
-  const totalApproved = data.reduce((sum, item) => sum + item.approved, 0);
-  const approvalRate = totalApplications > 0 
+  const totalApplications = normalizedData.reduce((sum, item) => sum + item.applications, 0);
+  const totalApproved = normalizedData.reduce((sum, item) => sum + item.approved, 0);
+  const approvalRate = totalApplications > 0
     ? ((totalApproved / totalApplications) * 100).toFixed(1)
     : 0;
 
@@ -36,7 +42,7 @@ export default function MonthlyChart({ data }) {
       {/* Bar Chart */}
       <div className="relative h-64">
         <div className="absolute inset-0 flex items-end justify-around px-2">
-          {data.map((stat, index) => (
+          {normalizedData.map((stat, index) => (
             <div key={index} className="flex flex-col items-center flex-1 mx-1">
               {/* Values on top of bars */}
               <div className="mb-2 text-center">

--- a/frontend_project_fund/app/member/components/dashboard/RecentApplications.js
+++ b/frontend_project_fund/app/member/components/dashboard/RecentApplications.js
@@ -1,36 +1,61 @@
 // dashboard/RecentApplications.js
 import StatusBadge from "../common/StatusBadge";
 
+const formatAmount = (value) => {
+  const amount = Number(value);
+  if (Number.isNaN(amount)) {
+    return "฿0";
+  }
+  return `฿${amount.toLocaleString("th-TH", { maximumFractionDigits: 0 })}`;
+};
+
 export default function RecentApplications({ applications = [] }) {
+  const items = Array.isArray(applications) ? applications : [];
+
+  if (items.length === 0) {
+    return <p className="text-center text-gray-500 py-8">ไม่มีคำร้องล่าสุด</p>;
+  }
+
   return (
     <div className="space-y-4">
-      {applications.length === 0 ? (
-        <p className="text-center text-gray-500 py-8">ไม่มีคำร้องล่าสุด</p>
-      ) : (
-        applications.map((app) => (
-          <div key={app.application_id} className="border rounded-lg p-4 hover:shadow-md transition-shadow">
-            <div className="flex justify-between items-start mb-2">
-              <div className="flex-1">
-                <h4 className="font-semibold text-gray-800">{app.project_title}</h4>
-                <p className="text-sm text-gray-600">เลขที่: {app.application_number}</p>
+      {items.map((app) => {
+        const key =
+          app.application_id ??
+          app.submission_id ??
+          app.application_number ??
+          `${app.project_title}-${app.submitted_at}`;
+
+        return (
+          <div key={key} className="border rounded-lg p-4 hover:shadow-md transition-shadow">
+            <div className="flex justify-between items-start mb-2 gap-4">
+              <div className="flex-1 min-w-0">
+                <h4 className="font-semibold text-gray-800 truncate">
+                  {app.project_title || app.title || "-"}
+                </h4>
+                <p className="text-sm text-gray-600">
+                  เลขที่: {app.application_number || app.submission_number || "-"}
+                </p>
               </div>
               <StatusBadge
                 statusId={
                   app.status_id ??
                   app.application_status_id ??
                   app.statusId ??
-                  app._original?.status_id
+                  app._original?.status_id ??
+                  app.status
                 }
                 fallbackLabel={app.status}
               />
             </div>
-            <div className="flex justify-between text-sm text-gray-600">
-              <span>{app.subcategory_name}</span>
-              <span>฿{app.requested_amount.toLocaleString()}</span>
+            <div className="flex justify-between text-sm text-gray-600 gap-4">
+              <span className="truncate">
+                {app.subcategory_name || app.category_name || "ไม่ระบุหมวดหมู่"}
+              </span>
+              <span className="font-semibold text-blue-600">{formatAmount(app.requested_amount ?? app.amount)}</span>
             </div>
           </div>
-        ))
-      )}
+        );
+      })}
     </div>
   );
 }

--- a/frontend_project_fund/app/utils/format.js
+++ b/frontend_project_fund/app/utils/format.js
@@ -1,52 +1,184 @@
 // app/utils/format.js
 
+const THAI_MONTHS = [
+  'มกราคม',
+  'กุมภาพันธ์',
+  'มีนาคม',
+  'เมษายน',
+  'พฤษภาคม',
+  'มิถุนายน',
+  'กรกฎาคม',
+  'สิงหาคม',
+  'กันยายน',
+  'ตุลาคม',
+  'พฤศจิกายน',
+  'ธันวาคม',
+];
+
+const THAI_MONTHS_SHORT = [
+  'ม.ค.',
+  'ก.พ.',
+  'มี.ค.',
+  'เม.ย.',
+  'พ.ค.',
+  'มิ.ย.',
+  'ก.ค.',
+  'ส.ค.',
+  'ก.ย.',
+  'ต.ค.',
+  'พ.ย.',
+  'ธ.ค.',
+];
+
+const normalizeDateInput = (value) => {
+  if (!value) return null;
+  if (value instanceof Date && !Number.isNaN(value.getTime())) {
+    return value;
+  }
+
+  if (typeof value === 'number') {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+
+  const isoLike = trimmed.includes('T') || trimmed.includes('Z')
+    ? trimmed
+    : trimmed.replace(' ', 'T');
+
+  const date = new Date(isoLike);
+  return Number.isNaN(date.getTime()) ? null : date;
+};
+
 // Format date to Thai locale
 export const formatDate = (date) => {
-  if (!date) return '-';
-  
-  const d = new Date(date);
+  const d = normalizeDateInput(date);
+  if (!d) return '-';
+
   const options = {
     year: 'numeric',
     month: 'long',
     day: 'numeric',
     hour: '2-digit',
-    minute: '2-digit'
+    minute: '2-digit',
   };
-  
+
   return d.toLocaleDateString('th-TH', options);
 };
 
 // Format date short (without time)
 export const formatDateShort = (date) => {
-  if (!date) return '-';
-  
-  const d = new Date(date);
+  const d = normalizeDateInput(date);
+  if (!d) return '-';
+
   const options = {
     year: 'numeric',
     month: 'short',
-    day: 'numeric'
+    day: 'numeric',
   };
-  
+
   return d.toLocaleDateString('th-TH', options);
 };
 
 // Format currency
 export const formatCurrency = (amount) => {
-  if (amount === null || amount === undefined) return '-';
-  
+  if (amount === null || amount === undefined || amount === '') return '-';
+
+  const numeric = Number(amount);
+  if (Number.isNaN(numeric)) return '-';
+
   return new Intl.NumberFormat('th-TH', {
     style: 'currency',
     currency: 'THB',
     minimumFractionDigits: 0,
-    maximumFractionDigits: 2
-  }).format(amount);
+    maximumFractionDigits: 2,
+  }).format(numeric);
 };
 
 // Format number with commas
 export const formatNumber = (num) => {
-  if (num === null || num === undefined) return '-';
-  
-  return new Intl.NumberFormat('th-TH').format(num);
+  if (num === null || num === undefined || num === '') return '-';
+
+  const numeric = Number(num);
+  if (Number.isNaN(numeric)) return '-';
+
+  return new Intl.NumberFormat('th-TH').format(numeric);
+};
+
+// Format Thai date from BE string (e.g. 2567-06-10)
+export const formatThaiDateFromBEString = (value) => {
+  if (!value) return '-';
+  if (typeof value !== 'string') {
+    return formatDateShort(value);
+  }
+
+  const [yearStr, monthStr, dayStr] = value.split('-');
+  if (!yearStr || !monthStr || !dayStr) {
+    return value;
+  }
+
+  const monthIndex = Number(monthStr) - 1;
+  if (Number.isNaN(monthIndex) || monthIndex < 0 || monthIndex >= THAI_MONTHS.length) {
+    return value;
+  }
+
+  const day = Number(dayStr);
+  const dayLabel = Number.isNaN(day) ? dayStr : day;
+
+  return `${dayLabel} ${THAI_MONTHS[monthIndex]} ${yearStr}`;
+};
+
+// Format Thai month (YYYY-MM) to short label, optionally including BE year
+export const formatThaiMonthShort = (value, options = {}) => {
+  const { includeYear = true } = options;
+  if (!value) return '-';
+
+  const parts = String(value).split(/[-/]/);
+  if (parts.length < 2) {
+    return value;
+  }
+
+  const [yearStr, monthStr] = parts;
+  const monthIndex = Number(monthStr) - 1;
+  const monthLabel = THAI_MONTHS_SHORT[monthIndex];
+
+  if (!monthLabel) {
+    return value;
+  }
+
+  if (!includeYear) {
+    return monthLabel;
+  }
+
+  const yearNum = Number(yearStr);
+  const thaiYear = Number.isNaN(yearNum) ? yearStr : yearNum + 543;
+  const shortYear = typeof thaiYear === 'number'
+    ? String(thaiYear).slice(-2)
+    : String(thaiYear).slice(-2);
+
+  return shortYear ? `${monthLabel} ${shortYear}` : monthLabel;
+};
+
+// Format Thai date time (adds น. suffix)
+export const formatThaiDateTime = (value) => {
+  const date = normalizeDateInput(value);
+  if (!date) return '-';
+
+  const day = date.getDate();
+  const monthLabel = THAI_MONTHS[date.getMonth()] || '';
+  const thaiYear = date.getFullYear() + 543;
+  const time = date.toLocaleTimeString('th-TH', {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+
+  return `${day} ${monthLabel} ${thaiYear} ${time} น.`;
 };
 
 // Get submission type text in Thai


### PR DESCRIPTION
## Summary
- rebuild the admin dashboard to consume live statistics, budget data, and pending submissions from the backend API with refreshed UI widgets
- connect the member dashboard to real API responses, add budget usage insights, and keep navigation actions responsive
- extend shared Thai formatting helpers and harden chart/budget components to handle API-provided values safely

## Testing
- npm run lint *(fails: Next.js lint prompts for configuration in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e367370a9c832aa9b3844560df9db8