### PR TITLE
Add head signature capture for department head reviews

### DIFF
--- a/frontend_project_fund/app/member/components/dept/details/GeneralSubmissionDetailsDept.js
+++ b/frontend_project_fund/app/member/components/dept/details/GeneralSubmissionDetailsDept.js
@@ -114,7 +114,8 @@ function getFileURL(filePath) {
 function DeptDecisionPanel({ submission, onApprove, onReject }) {
   const [comment, setComment] = useState(
     submission?.head_comment ?? submission?.comment ?? ''
-  );  
+  );
+  const [signature, setSignature] = useState(submission?.head_signature ?? '');
   const [saving, setSaving] = useState(false);
 
   const statusId = Number(submission?.status_id);
@@ -144,7 +145,9 @@ function DeptDecisionPanel({ submission, onApprove, onReject }) {
         try {
           setSaving(true);
           // ส่งหมายเหตุ (comment/head_comment) ไปเก็บที่ submissions เท่านั้น
-          await onApprove(comment?.trim() || '');
+          const trimmedComment = comment?.trim() ?? '';
+          const trimmedSignature = signature?.trim() ?? '';
+          await onApprove(trimmedComment, trimmedSignature);
         } catch (e) {
           Swal.showValidationMessage(e?.message || 'อนุมัติไม่สำเร็จ');
           throw e;
@@ -198,7 +201,9 @@ function DeptDecisionPanel({ submission, onApprove, onReject }) {
         try {
           setSaving(true);
           // ส่งเหตุผล + หมายเหตุหัวหน้าสาขา (comment) ไปหลังบ้าน (เก็บที่ submissions เท่านั้น)
-          await onReject(String(reason).trim(), comment?.trim() || '');
+          const trimmedComment = comment?.trim() ?? '';
+          const trimmedSignature = signature?.trim() ?? '';
+          await onReject(String(reason).trim(), trimmedComment, trimmedSignature);
         } catch (e) {
           Swal.showValidationMessage(e?.message || 'ไม่อนุมัติไม่สำเร็จ');
           throw e;
@@ -224,6 +229,18 @@ function DeptDecisionPanel({ submission, onApprove, onReject }) {
             placeholder="เขียนหมายเหตุของหัวหน้าสาขาหรือบันทึกหมายเหตุ (ถ้ามี)"
             value={comment}
             onChange={(e) => setComment(e.target.value)}
+            disabled={saving}
+          />
+        </div>
+
+        <div>
+          <label className="text-sm text-gray-600">ลายเซ็นหัวหน้าสาขา (พิมพ์ชื่อเต็ม)</label>
+          <input
+            type="text"
+            className="w-full rounded-lg border border-gray-300 p-3 outline-none focus:ring-2 focus:ring-blue-500"
+            placeholder="พิมพ์ชื่อ-นามสกุลหัวหน้าสาขา"
+            value={signature}
+            onChange={(e) => setSignature(e.target.value)}
             disabled={saving}
           />
         </div>
@@ -695,8 +712,15 @@ export default function GeneralSubmissionDetailsDept({ submissionId, onBack }) {
 
   // ===== Approve/Reject handlers (Dept) =====
   // รับ headComment จากแผง แล้วส่งไปกับ recommendSubmission
-  const approve = async (headComment) => {
-    const body = headComment ? { head_comment: headComment, comment: headComment } : {};
+  const approve = async (headComment, headSignature) => {
+    const body = {};
+    if (headComment) {
+      body.head_comment = headComment;
+      body.comment = headComment;
+    }
+    if (headSignature !== undefined) {
+      body.head_signature = headSignature;
+    }
     await deptHeadAPI.recommendSubmission(submission.submission_id, body);
     // refresh
     const res = await deptHeadAPI.getSubmissionDetails(submission.submission_id);
@@ -710,11 +734,14 @@ export default function GeneralSubmissionDetailsDept({ submissionId, onBack }) {
   };
 
   // ส่งเหตุผลปฏิเสธ + (ถ้ามี) คอมเมนต์ของหัวหน้าสาขา
-  const reject = async (reason, headComment) => {
+  const reject = async (reason, headComment, headSignature) => {
     const payload = { rejection_reason: reason };
     if (headComment) {
       payload.head_comment = headComment;
       payload.comment = headComment; // เผื่อระบบเดิมอ่านจาก comment
+    }
+    if (headSignature !== undefined) {
+      payload.head_signature = headSignature;
     }
     await deptHeadAPI.rejectSubmission(submission.submission_id, payload);
     // refresh

--- a/frontend_project_fund/app/member/components/dept/details/PublicationSubmissionDetailsDept.js
+++ b/frontend_project_fund/app/member/components/dept/details/PublicationSubmissionDetailsDept.js
@@ -345,7 +345,8 @@ function ReadonlyMoney({ value, aria }) {
 function DeptDecisionPanel({ submission, onApprove, onReject }) {
   const [comment, setComment] = useState(
     submission?.head_comment ?? submission?.comment ?? ''
-  );  
+  );
+  const [signature, setSignature] = useState(submission?.head_signature ?? '');
   const [saving, setSaving] = useState(false);
 
   const canAct = true;
@@ -374,7 +375,9 @@ function DeptDecisionPanel({ submission, onApprove, onReject }) {
         try {
           setSaving(true);
           // ส่งหมายเหตุ (comment/head_comment) ไปเก็บที่ submissions เท่านั้น
-          await onApprove(comment?.trim() || '');
+          const trimmedComment = comment?.trim() ?? '';
+          const trimmedSignature = signature?.trim() ?? '';
+          await onApprove(trimmedComment, trimmedSignature);
         } catch (e) {
           Swal.showValidationMessage(e?.message || 'อนุมัติไม่สำเร็จ');
           throw e;
@@ -428,7 +431,9 @@ function DeptDecisionPanel({ submission, onApprove, onReject }) {
         try {
           setSaving(true);
           // ส่งเหตุผล + หมายเหตุหัวหน้าสาขา (comment) ไปหลังบ้าน (เก็บที่ submissions เท่านั้น)
-          await onReject(String(reason).trim(), comment?.trim() || '');
+          const trimmedComment = comment?.trim() ?? '';
+          const trimmedSignature = signature?.trim() ?? '';
+          await onReject(String(reason).trim(), trimmedComment, trimmedSignature);
         } catch (e) {
           Swal.showValidationMessage(e?.message || 'ไม่อนุมัติไม่สำเร็จ');
           throw e;
@@ -455,6 +460,18 @@ function DeptDecisionPanel({ submission, onApprove, onReject }) {
             placeholder="เขียนหมายเหตุของหัวหน้าสาขาหรือบันทึกหมายเหตุ (ถ้ามี)"
             value={comment}
             onChange={(e) => setComment(e.target.value)}
+            disabled={saving}
+          />
+        </div>
+
+        <div>
+          <label className="text-sm text-gray-600">ลายเซ็นหัวหน้าสาขา (พิมพ์ชื่อเต็ม)</label>
+          <input
+            type="text"
+            className="w-full rounded-lg border border-gray-300 p-3 outline-none focus:ring-2 focus:ring-blue-500"
+            placeholder="พิมพ์ชื่อ-นามสกุลหัวหน้าสาขา"
+            value={signature}
+            onChange={(e) => setSignature(e.target.value)}
             disabled={saving}
           />
         </div>
@@ -1282,8 +1299,15 @@ export default function PublicationSubmissionDetailsDept({ submissionId, onBack 
   }, []);
 
   // ==== PATCH: handlers ภายใน component หลัก PublicationSubmissionDetailsDept ====
-  const approve = async (headComment) => {
-    const body = headComment ? { head_comment: headComment, comment: headComment } : {};
+  const approve = async (headComment, headSignature) => {
+    const body = {};
+    if (headComment) {
+      body.head_comment = headComment;
+      body.comment = headComment;
+    }
+    if (headSignature !== undefined) {
+      body.head_signature = headSignature;
+    }
     await deptHeadAPI.recommendSubmission(submission.submission_id, body);
 
     // reload details หลังบันทึก
@@ -1297,11 +1321,14 @@ export default function PublicationSubmissionDetailsDept({ submissionId, onBack 
     setSubmission(data);
   };
 
-  const reject = async (reason, headComment) => {
+  const reject = async (reason, headComment, headSignature) => {
     const payload = { rejection_reason: reason };
     if (headComment) {
       payload.head_comment = headComment;
       payload.comment = headComment; // เผื่อจุดเก่าอ่านจาก comment
+    }
+    if (headSignature !== undefined) {
+      payload.head_signature = headSignature;
     }
     await deptHeadAPI.rejectSubmission(submission.submission_id, payload);
 

--- a/fund-management-api/controllers/dept_head_submission.go
+++ b/fund-management-api/controllers/dept_head_submission.go
@@ -124,7 +124,8 @@ func DeptHeadRecommendSubmission(c *gin.Context) {
 	}
 
 	var req struct {
-		Comment string `json:"comment"`
+		Comment       string `json:"comment"`
+		HeadSignature string `json:"head_signature"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil && !strings.Contains(err.Error(), "EOF") {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request payload"})
@@ -186,6 +187,13 @@ func DeptHeadRecommendSubmission(c *gin.Context) {
 		updates["comment"] = gorm.Expr("NULL")
 	}
 
+	headSignature := strings.TrimSpace(req.HeadSignature)
+	if headSignature != "" {
+		updates["head_signature"] = headSignature
+	} else {
+		updates["head_signature"] = gorm.Expr("NULL")
+	}
+
 	if err := tx.Model(&models.Submission{}).
 		Where("submission_id = ?", submissionID).
 		Updates(updates).Error; err != nil {
@@ -241,6 +249,7 @@ func DeptHeadRejectSubmission(c *gin.Context) {
 	var req struct {
 		RejectionReason string `json:"rejection_reason" binding:"required"`
 		Comment         string `json:"comment"`
+		HeadSignature   string `json:"head_signature"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil || strings.TrimSpace(req.RejectionReason) == "" {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Rejection reason is required"})
@@ -289,8 +298,16 @@ func DeptHeadRejectSubmission(c *gin.Context) {
 		"head_rejected_at":      now,
 		"head_rejection_reason": strings.TrimSpace(req.RejectionReason),
 	}
-	if strings.TrimSpace(req.Comment) != "" {
-		updates["head_comment"] = strings.TrimSpace(req.Comment)
+	trimmedComment := strings.TrimSpace(req.Comment)
+	if trimmedComment != "" {
+		updates["head_comment"] = trimmedComment
+	}
+
+	headSignature := strings.TrimSpace(req.HeadSignature)
+	if headSignature != "" {
+		updates["head_signature"] = headSignature
+	} else {
+		updates["head_signature"] = gorm.Expr("NULL")
 	}
 
 	if err := tx.Model(&models.Submission{}).
@@ -472,6 +489,7 @@ func buildSubmissionDetailPayload(submissionID int) (gin.H, error) {
 		"head_rejected_at":       submission.HeadRejectedAt,
 		"head_rejection_reason":  submission.HeadRejectionReason,
 		"head_comment":           submission.HeadComment,
+		"head_signature":         submission.HeadSignature,
 		"admin_approved_by":      submission.AdminApprovedBy,
 		"admin_approved_at":      submission.AdminApprovedAt,
 		"admin_rejected_by":      submission.AdminRejectedBy,

--- a/fund-management-api/models/submission.go
+++ b/fund-management-api/models/submission.go
@@ -36,6 +36,7 @@ type Submission struct {
 	HeadRejectedAt      *time.Time `gorm:"column:head_rejected_at" json:"head_rejected_at,omitempty"`
 	HeadRejectionReason *string    `gorm:"column:head_rejection_reason" json:"head_rejection_reason,omitempty"`
 	HeadComment         *string    `gorm:"column:head_comment" json:"head_comment,omitempty"`
+	HeadSignature       *string    `gorm:"column:head_signature" json:"head_signature,omitempty"`
 
 	// ===== ADD: Admin rejection (split) =====
 	AdminRejectedBy      *int       `gorm:"column:admin_rejected_by" json:"admin_rejected_by,omitempty"`


### PR DESCRIPTION
## Summary
- add a department head signature input to both general and publication review panels
- send the captured signature with approve/reject actions so the backend stores it on submissions
- expose the saved head_signature field from the department head submission endpoints

## Testing
- go test ./... *(hangs in current environment; command interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68e3afef49bc832a8dfe6ba5cc3490ec