### PR TITLE
Normalize research fund event creator details

### DIFF
--- a/frontend_project_fund/app/lib/admin_submission_api.js
+++ b/frontend_project_fund/app/lib/admin_submission_api.js
@@ -93,6 +93,16 @@ const toUserId = (value) => {
   return null;
 };
 
+const normalizeUserDisplayName = (...candidates) => {
+  for (const candidate of candidates) {
+    const name = toUserName(candidate);
+    if (name) {
+      return name;
+    }
+  }
+  return null;
+};
+
 const normalizeResearchFundEvent = (event = {}) => {
   const attachment = normalizeEventAttachment(event);
   const amount = toNumberOrNull(
@@ -138,14 +148,14 @@ const normalizeResearchFundEvent = (event = {}) => {
         event?.creator_id
       ) ?? null,
     created_by_name:
-      pickFirst(
-        toUserName(event?.created_by_name),
-        toUserName(creatorCandidate),
+      normalizeUserDisplayName(
+        event?.created_by_name,
+        creatorCandidate,
         event?.creator_name,
         event?.created_by_full_name,
         event?.creator,
         event?.user_name
-      ) || null,
+      ),
     attachment,
     file_id: attachment?.file_id ?? null,
     file_name: attachment?.file_name ?? null,


### PR DESCRIPTION
## Summary
- normalize research fund event creator values returned by the admin API
- ensure creator ids and names are extracted from nested user objects to prevent rendering errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3cd2826608322b98862f310e0b4bc