### PR TITLE
Add department head signature inputs to review panels

### DIFF
--- a/frontend_project_fund/app/member/components/dept/details/GeneralSubmissionDetailsDept.js
+++ b/frontend_project_fund/app/member/components/dept/details/GeneralSubmissionDetailsDept.js
@@ -114,19 +114,28 @@ function getFileURL(filePath) {
 function DeptDecisionPanel({ submission, onApprove, onReject, onBack }) {
   const [comment, setComment] = useState(
     submission?.head_comment ?? submission?.comment ?? ''
-  );  
+  );
+  const [headSignature, setHeadSignature] = useState(
+    submission?.head_signature ?? ''
+  );
   const [saving, setSaving] = useState(false);
 
   const statusId = Number(submission?.status_id);
   const canAct = statusId === 1 || String(submission?.status?.status_code || '').toLowerCase() === 'pending';
 
   const handleApprove = async () => {
+    const trimmedSignature = headSignature?.trim() || '';
     const html = `
       <div style="text-align:left;font-size:14px;line-height:1.6;">
         ${comment?.trim()
           ? `<div style="font-weight:500;margin-bottom:.25rem;">หมายเหตุจากหัวหน้าสาขา</div>
             <div style="border:1px solid #e5e7eb;background:#f9fafb;padding:.5rem;border-radius:.5rem;">${comment.replace(/</g,'&lt;').replace(/>/g,'&gt;')}</div>`
           : `<div style="font-size:12px;color:#6b7280;">(ไม่มีหมายเหตุ)</div>`
+        }
+        ${trimmedSignature
+          ? `<div style="font-weight:500;margin:.75rem 0 .25rem;">ลายเซ็นหัวหน้าสาขา</div>
+            <div style="border:1px solid #e5e7eb;background:#f9fafb;padding:.5rem;border-radius:.5rem;">${trimmedSignature.replace(/</g,'&lt;').replace(/>/g,'&gt;')}</div>`
+          : ''
         }
       </div>
     `;
@@ -144,7 +153,7 @@ function DeptDecisionPanel({ submission, onApprove, onReject, onBack }) {
         try {
           setSaving(true);
           // ส่งหมายเหตุ (comment/head_comment) ไปเก็บที่ submissions เท่านั้น
-          await onApprove(comment?.trim() || '');
+          await onApprove(comment?.trim() || '', trimmedSignature);
         } catch (e) {
           Swal.showValidationMessage(e?.message || 'อนุมัติไม่สำเร็จ');
           throw e;
@@ -199,7 +208,7 @@ function DeptDecisionPanel({ submission, onApprove, onReject, onBack }) {
         try {
           setSaving(true);
           // ส่งเหตุผล + หมายเหตุหัวหน้าสาขา (comment) ไปหลังบ้าน (เก็บที่ submissions เท่านั้น)
-          await onReject(String(reason).trim(), comment?.trim() || '');
+          await onReject(String(reason).trim(), comment?.trim() || '', headSignature?.trim() || '');
         } catch (e) {
           Swal.showValidationMessage(e?.message || 'ไม่อนุมัติไม่สำเร็จ');
           throw e;
@@ -226,6 +235,18 @@ function DeptDecisionPanel({ submission, onApprove, onReject, onBack }) {
             placeholder="เขียนหมายเหตุของหัวหน้าสาขาหรือบันทึกหมายเหตุ (ถ้ามี)"
             value={comment}
             onChange={(e) => setComment(e.target.value)}
+            disabled={saving}
+          />
+        </div>
+
+        <div>
+          <label className="text-sm text-gray-600">ลายเซ็นหัวหน้าสาขา (พิมพ์ชื่อเต็ม)</label>
+          <input
+            type="text"
+            className="w-full rounded-lg border border-gray-300 p-3 outline-none focus:ring-2 focus:ring-blue-500"
+            placeholder="กรอกชื่อ-นามสกุลหัวหน้าสาขา"
+            value={headSignature}
+            onChange={(e) => setHeadSignature(e.target.value)}
             disabled={saving}
           />
         </div>
@@ -697,8 +718,17 @@ export default function GeneralSubmissionDetailsDept({ submissionId, onBack }) {
 
   // ===== Approve/Reject handlers (Dept) =====
   // รับ headComment จากแผง แล้วส่งไปกับ recommendSubmission
-  const approve = async (headComment) => {
-    const body = headComment ? { head_comment: headComment, comment: headComment } : {};
+  const approve = async (headComment, headSignature) => {
+    const body = {};
+    const trimmedComment = typeof headComment === 'string' ? headComment.trim() : '';
+    if (trimmedComment) {
+      body.head_comment = trimmedComment;
+      body.comment = trimmedComment;
+    }
+    const signature = typeof headSignature === 'string' ? headSignature.trim() : '';
+    if (signature) {
+      body.head_signature = signature;
+    }
     await deptHeadAPI.recommendSubmission(submission.submission_id, body);
     // refresh
     const res = await deptHeadAPI.getSubmissionDetails(submission.submission_id);
@@ -712,11 +742,16 @@ export default function GeneralSubmissionDetailsDept({ submissionId, onBack }) {
   };
 
   // ส่งเหตุผลปฏิเสธ + (ถ้ามี) คอมเมนต์ของหัวหน้าสาขา
-  const reject = async (reason, headComment) => {
+  const reject = async (reason, headComment, headSignature) => {
     const payload = { rejection_reason: reason };
-    if (headComment) {
-      payload.head_comment = headComment;
-      payload.comment = headComment; // เผื่อระบบเดิมอ่านจาก comment
+    const trimmedComment = typeof headComment === 'string' ? headComment.trim() : '';
+    if (trimmedComment) {
+      payload.head_comment = trimmedComment;
+      payload.comment = trimmedComment; // เผื่อระบบเดิมอ่านจาก comment
+    }
+    const signature = typeof headSignature === 'string' ? headSignature.trim() : '';
+    if (signature) {
+      payload.head_signature = signature;
     }
     await deptHeadAPI.rejectSubmission(submission.submission_id, payload);
     // refresh

--- a/frontend_project_fund/app/member/components/dept/details/PublicationSubmissionDetailsDept.js
+++ b/frontend_project_fund/app/member/components/dept/details/PublicationSubmissionDetailsDept.js
@@ -345,18 +345,27 @@ function ReadonlyMoney({ value, aria }) {
 function DeptDecisionPanel({ submission, onApprove, onReject, onBack }) {
   const [comment, setComment] = useState(
     submission?.head_comment ?? submission?.comment ?? ''
-  );  
+  );
+  const [headSignature, setHeadSignature] = useState(
+    submission?.head_signature ?? ''
+  );
   const [saving, setSaving] = useState(false);
 
   const canAct = true;
 
   const handleApprove = async () => {
+    const trimmedSignature = headSignature?.trim() || '';
     const html = `
       <div style="text-align:left;font-size:14px;line-height:1.6;">
         ${comment?.trim()
           ? `<div style="font-weight:500;margin-bottom:.25rem;">หมายเหตุจากหัวหน้าสาขา</div>
             <div style="border:1px solid #e5e7eb;background:#f9fafb;padding:.5rem;border-radius:.5rem;">${comment.replace(/</g,'&lt;').replace(/>/g,'&gt;')}</div>`
           : `<div style="font-size:12px;color:#6b7280;">(ไม่มีหมายเหตุ)</div>`
+        }
+        ${trimmedSignature
+          ? `<div style="font-weight:500;margin:.75rem 0 .25rem;">ลายเซ็นหัวหน้าสาขา</div>
+            <div style="border:1px solid #e5e7eb;background:#f9fafb;padding:.5rem;border-radius:.5rem;">${trimmedSignature.replace(/</g,'&lt;').replace(/>/g,'&gt;')}</div>`
+          : ''
         }
       </div>
     `;
@@ -374,7 +383,7 @@ function DeptDecisionPanel({ submission, onApprove, onReject, onBack }) {
         try {
           setSaving(true);
           // ส่งหมายเหตุ (comment/head_comment) ไปเก็บที่ submissions เท่านั้น
-          await onApprove(comment?.trim() || '');
+          await onApprove(comment?.trim() || '', trimmedSignature);
         } catch (e) {
           Swal.showValidationMessage(e?.message || 'อนุมัติไม่สำเร็จ');
           throw e;
@@ -429,7 +438,7 @@ function DeptDecisionPanel({ submission, onApprove, onReject, onBack }) {
         try {
           setSaving(true);
           // ส่งเหตุผล + หมายเหตุหัวหน้าสาขา (comment) ไปหลังบ้าน (เก็บที่ submissions เท่านั้น)
-          await onReject(String(reason).trim(), comment?.trim() || '');
+          await onReject(String(reason).trim(), comment?.trim() || '', headSignature?.trim() || '');
         } catch (e) {
           Swal.showValidationMessage(e?.message || 'ไม่อนุมัติไม่สำเร็จ');
           throw e;
@@ -457,6 +466,18 @@ function DeptDecisionPanel({ submission, onApprove, onReject, onBack }) {
             placeholder="เขียนหมายเหตุของหัวหน้าสาขาหรือบันทึกหมายเหตุ (ถ้ามี)"
             value={comment}
             onChange={(e) => setComment(e.target.value)}
+            disabled={saving}
+          />
+        </div>
+
+        <div>
+          <label className="text-sm text-gray-600">ลายเซ็นหัวหน้าสาขา (พิมพ์ชื่อเต็ม)</label>
+          <input
+            type="text"
+            className="w-full rounded-lg border border-gray-300 p-3 outline-none focus:ring-2 focus:ring-blue-500"
+            placeholder="กรอกชื่อ-นามสกุลหัวหน้าสาขา"
+            value={headSignature}
+            onChange={(e) => setHeadSignature(e.target.value)}
             disabled={saving}
           />
         </div>
@@ -1284,8 +1305,17 @@ export default function PublicationSubmissionDetailsDept({ submissionId, onBack 
   }, []);
 
   // ==== PATCH: handlers ภายใน component หลัก PublicationSubmissionDetailsDept ====
-  const approve = async (headComment) => {
-    const body = headComment ? { head_comment: headComment, comment: headComment } : {};
+  const approve = async (headComment, headSignature) => {
+    const body = {};
+    const trimmedComment = typeof headComment === 'string' ? headComment.trim() : '';
+    if (trimmedComment) {
+      body.head_comment = trimmedComment;
+      body.comment = trimmedComment;
+    }
+    const signature = typeof headSignature === 'string' ? headSignature.trim() : '';
+    if (signature) {
+      body.head_signature = signature;
+    }
     await deptHeadAPI.recommendSubmission(submission.submission_id, body);
 
     // reload details หลังบันทึก
@@ -1299,11 +1329,16 @@ export default function PublicationSubmissionDetailsDept({ submissionId, onBack 
     setSubmission(data);
   };
 
-  const reject = async (reason, headComment) => {
+  const reject = async (reason, headComment, headSignature) => {
     const payload = { rejection_reason: reason };
-    if (headComment) {
-      payload.head_comment = headComment;
-      payload.comment = headComment; // เผื่อจุดเก่าอ่านจาก comment
+    const trimmedComment = typeof headComment === 'string' ? headComment.trim() : '';
+    if (trimmedComment) {
+      payload.head_comment = trimmedComment;
+      payload.comment = trimmedComment; // เผื่อจุดเก่าอ่านจาก comment
+    }
+    const signature = typeof headSignature === 'string' ? headSignature.trim() : '';
+    if (signature) {
+      payload.head_signature = signature;
     }
     await deptHeadAPI.rejectSubmission(submission.submission_id, payload);
 


### PR DESCRIPTION
## Summary
- add a department head signature text input to the review panels on general and publication submission detail pages
- include the optional head signature in approve and reject payloads so it persists with submissions

## Testing
- `npm run lint` *(fails: prompts for ESLint setup interactively)*

------
https://chatgpt.com/codex/tasks/task_e_68e4291895f0832abcd56818fa238add