### PR TITLE
Fix file upload persistence without metadata column

### DIFF
--- a/fund-management-api/controllers/admin_submission.go
+++ b/fund-management-api/controllers/admin_submission.go
@@ -1301,7 +1301,6 @@ func buildResearchFundEventsPayload(events []models.ResearchFundAdminEvent) []gi
 					"original_name": ef.File.OriginalName,
 					"stored_path":   ef.File.StoredPath,
 					"folder_type":   ef.File.FolderType,
-					"metadata":      ef.File.Metadata,
 					"mime_type":     ef.File.MimeType,
 					"file_size":     ef.File.FileSize,
 					"uploaded_at":   ef.File.UploadedAt,

--- a/fund-management-api/controllers/document.go
+++ b/fund-management-api/controllers/document.go
@@ -120,6 +120,7 @@ func UploadDocument(c *gin.Context) {
 	fileUpload := models.FileUpload{
 		OriginalName: file.Filename,
 		StoredPath:   fullPath,
+		FolderType:   models.FileFolderTypeSubmission,
 		FileSize:     file.Size,
 		MimeType:     file.Header.Get("Content-Type"),
 		FileHash:     "", // ไม่ใช้ hash ในระบบ user-based
@@ -130,7 +131,7 @@ func UploadDocument(c *gin.Context) {
 		UpdateAt:     now,
 	}
 
-	if err := config.DB.Create(&fileUpload).Error; err != nil {
+	if err := config.DB.Omit("Metadata").Create(&fileUpload).Error; err != nil {
 		// Delete uploaded file if database save fails
 		os.Remove(fullPath)
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save file info"})

--- a/fund-management-api/controllers/publication.go
+++ b/fund-management-api/controllers/publication.go
@@ -451,7 +451,7 @@ func CreatePublicationReward(c *gin.Context) {
 					UpdateAt:     now,
 				}
 
-				if err := tx.Create(&fileUpload).Error; err != nil {
+				if err := tx.Omit("Metadata").Create(&fileUpload).Error; err != nil {
 					tx.Rollback()
 					os.Remove(dst)
 					c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save file info"})
@@ -850,6 +850,7 @@ func UploadPublicationDocument(c *gin.Context) {
 			fileUpload := models.FileUpload{
 				OriginalName: fileHeader.Filename,
 				StoredPath:   dst,
+				FolderType:   models.FileFolderTypeSubmission,
 				FileSize:     fileHeader.Size,
 				MimeType:     fileHeader.Header.Get("Content-Type"),
 				FileHash:     "", // ไม่ใช้ hash ในระบบ user-based
@@ -860,7 +861,7 @@ func UploadPublicationDocument(c *gin.Context) {
 				UpdateAt:     now,
 			}
 
-			if err := config.DB.Create(&fileUpload).Error; err != nil {
+			if err := config.DB.Omit("Metadata").Create(&fileUpload).Error; err != nil {
 				// Delete uploaded file if database save fails
 				os.Remove(dst)
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save file info"})

--- a/fund-management-api/controllers/submission.go
+++ b/fund-management-api/controllers/submission.go
@@ -807,6 +807,7 @@ func UploadFile(c *gin.Context) {
 	fileUpload := models.FileUpload{
 		OriginalName: file.Filename,
 		StoredPath:   storedPath,
+		FolderType:   models.FileFolderTypeTemp,
 		FileSize:     file.Size,
 		MimeType:     file.Header.Get("Content-Type"),
 		FileHash:     "", // ไม่ใช้ hash ในระบบ user-based
@@ -900,6 +901,7 @@ func MoveFileToSubmissionFolder(fileID int, submissionID int, submissionType str
 
 	// Update DB path (เก็บ OriginalName ตามเดิมไว้ เพื่อแสดงชื่อไฟล์เดิมใน UI ได้ถ้าต้องการ)
 	fileUpload.StoredPath = newPath
+	fileUpload.FolderType = models.FileFolderTypeSubmission
 	fileUpload.UpdateAt = time.Now()
 	return config.DB.Save(&fileUpload).Error
 }

--- a/fund-management-api/models/common.go
+++ b/fund-management-api/models/common.go
@@ -23,7 +23,6 @@ type FileUpload struct {
 	OriginalName string     `gorm:"column:original_name" json:"original_name"`
 	StoredPath   string     `gorm:"column:stored_path" json:"stored_path"`
 	FolderType   string     `gorm:"column:folder_type" json:"folder_type"`
-	Metadata     string     `gorm:"column:metadata" json:"metadata"`
 	FileSize     int64      `gorm:"column:file_size" json:"file_size"`
 	MimeType     string     `gorm:"column:mime_type" json:"mime_type"`
 	FileHash     string     `gorm:"column:file_hash" json:"file_hash"` // เก็บไว้แต่ไม่ใช้


### PR DESCRIPTION
## Summary
- drop the unused metadata field from FileUpload so inserts and updates match the database schema
- mark moved uploads as submission files and stop returning metadata from admin event payloads

## Testing
- go test ./... *(fails: command cancelled because it hung in the container environment)*
- go build ./... *(fails: command cancelled because it hung in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4f9a894c8832aa557fa36b3d6f3f9