### PR TITLE
Remove redundant fund summary cards from fund views

### DIFF
--- a/frontend_project_fund/app/admin/components/funds/PromotionFundContent.js
+++ b/frontend_project_fund/app/admin/components/funds/PromotionFundContent.js
@@ -660,47 +660,6 @@ export default function PromotionFundContent() {
         </div>
       </div>
 
-      {filteredFunds.length > 0 && (
-        <div className="mb-4 grid grid-cols-1 md:grid-cols-3 gap-4">
-          <div className="bg-white p-4 rounded-lg shadow-sm">
-            <div className="text-sm text-gray-500">จำนวนทุนทั้งหมด</div>
-            <div className="text-2xl font-semibold text-gray-900">
-              {filteredFunds.reduce(
-                (sum, cat) => sum + (cat.subcategories?.length || 0),
-                0
-              )}
-            </div>
-          </div>
-          <div className="bg-white p-4 rounded-lg shadow-sm">
-            <div className="text-sm text-gray-500">ทุนที่มีงบประมาณ</div>
-            <div className="text-2xl font-semibold text-green-600">
-              {filteredFunds.reduce(
-                (sum, cat) =>
-                  sum +
-                  (cat.subcategories?.filter((s) => parseBudgetValue(s.remaining_budget) > 0).length || 0),
-                0
-              )}
-            </div>
-          </div>
-          <div className="bg-white p-4 rounded-lg shadow-sm">
-            <div className="text-sm text-gray-500">งบประมาณรวมคงเหลือ</div>
-            <div className="text-xl font-semibold text-blue-600">
-              {formatAmount(
-                filteredFunds.reduce(
-                  (sum, cat) =>
-                    sum +
-                    (cat.subcategories?.reduce(
-                      (subSum, sub) => subSum + parseBudgetValue(sub.remaining_budget),
-                      0
-                    ) || 0),
-                  0
-                )
-              )}
-            </div>
-          </div>
-        </div>
-      )}
-
       {filteredFunds.length === 0 ? (
         <div className="bg-white rounded-lg shadow-sm p-8 text-center">
           <div className="text-gray-500">

--- a/frontend_project_fund/app/admin/components/funds/ResearchFundContent.js
+++ b/frontend_project_fund/app/admin/components/funds/ResearchFundContent.js
@@ -530,46 +530,6 @@ export default function ResearchFundContent() {
         </div>
       </div>
 
-      {filteredFunds.length > 0 && (
-        <div className="mb-4 grid grid-cols-1 md:grid-cols-3 gap-4">
-          <div className="bg-white p-4 rounded-lg shadow-sm">
-            <div className="text-sm text-gray-500">จำนวนทุนทั้งหมด</div>
-            <div className="text-2xl font-semibold text-gray-900">
-              {filteredFunds.reduce(
-                (sum, cat) => sum + (cat.subcategories?.length || 0),
-                0
-              )}
-            </div>
-          </div>
-          <div className="bg-white p-4 rounded-lg shadow-sm">
-            <div className="text-sm text-gray-500">ทุนที่มีงบประมาณ</div>
-            <div className="text-2xl font-semibold text-green-600">
-              {filteredFunds.reduce(
-                (sum, cat) =>
-                  sum + (cat.subcategories?.filter((s) => isAvailableResearch(s)).length || 0),
-                0
-              )}
-            </div>
-          </div>
-          <div className="bg-white p-4 rounded-lg shadow-sm">
-            <div className="text-sm text-gray-500">งบประมาณรวมคงเหลือ</div>
-            <div className="text-xl font-semibold text-blue-600">
-              {formatAmount(
-                filteredFunds.reduce(
-                  (sum, cat) =>
-                    sum +
-                    (cat.subcategories?.reduce(
-                      (subSum, sub) => subSum + (sub.remaining_budget || 0),
-                      0
-                    ) || 0),
-                  0
-                )
-              )}
-            </div>
-          </div>
-        </div>
-      )}
-
       {filteredFunds.length === 0 ? (
         <div className="bg-white rounded-lg shadow-sm p-8 text-center">
           <div className="text-gray-500">

--- a/frontend_project_fund/app/member/components/funds/PromotionFundContent.js
+++ b/frontend_project_fund/app/member/components/funds/PromotionFundContent.js
@@ -624,11 +624,11 @@ export default function PromotionFundContent({ onNavigate }) {
                         ? "อยู่นอกช่วงเวลายื่นขอ"
                         : remainingBudget === 0
                         ? "งบประมาณหมดแล้ว"
-                        : "กรอกแบบฟอร์ม"
+                        : "ยื่นขอทุน"
                     }
                   >
                     <ButtonIcon size={16} />
-                    กรอกแบบฟอร์ม
+                    ยื่นขอทุน
                   </button>
                 </div>
               );
@@ -717,37 +717,6 @@ export default function PromotionFundContent({ onNavigate }) {
           </div>
         </div>
       </div>
-
-      {/* Summary Stats (Optional) */}
-      {filteredFunds.length > 0 && (
-        <div className="mb-4 grid grid-cols-3 gap-4">
-          <div className="bg-white p-4 rounded-lg shadow-sm">
-            <div className="text-sm text-gray-500">จำนวนทุนทั้งหมด</div>
-            <div className="text-2xl font-semibold text-gray-900">
-              {filteredFunds.reduce((sum, cat) => sum + (cat.subcategories?.length || 0), 0)}
-            </div>
-          </div>
-          <div className="bg-white p-4 rounded-lg shadow-sm">
-            <div className="text-sm text-gray-500">ทุนที่มีงบประมาณ</div>
-            <div className="text-2xl font-semibold text-green-600">
-              {filteredFunds.reduce((sum, cat) => 
-                sum + (cat.subcategories?.filter(s => s.remaining_budget > 0).length || 0), 0
-              )}
-            </div>
-          </div>
-          <div className="bg-white p-4 rounded-lg shadow-sm">
-            <div className="text-sm text-gray-500">งบประมาณรวมคงเหลือ</div>
-            <div className="text-xl font-semibold text-blue-600">
-              {formatAmount(
-                filteredFunds.reduce((sum, cat) => 
-                  sum + (cat.subcategories?.reduce((subSum, sub) => 
-                    subSum + (sub.remaining_budget || 0), 0) || 0), 0
-                )
-              )}
-            </div>
-          </div>
-        </div>
-      )}
 
       {/* Funds Table */}
       {filteredFunds.length === 0 ? (

--- a/frontend_project_fund/app/member/components/funds/ResearchFundContent.js
+++ b/frontend_project_fund/app/member/components/funds/ResearchFundContent.js
@@ -630,48 +630,6 @@ export default function ResearchFundContent({ onNavigate }) {
         </div>
       </div>
 
-      {/* Summary Stats (เหมือน Promotion แต่ใช้เกณฑ์ isAvailableResearch) */}
-      {filteredFunds.length > 0 && (
-        <div className="mb-4 grid grid-cols-3 gap-4">
-          <div className="bg-white p-4 rounded-lg shadow-sm">
-            <div className="text-sm text-gray-500">จำนวนทุนทั้งหมด</div>
-            <div className="text-2xl font-semibold text-gray-900">
-              {filteredFunds.reduce(
-                (sum, cat) => sum + (cat.subcategories?.length || 0),
-                0
-              )}
-            </div>
-          </div>
-          <div className="bg-white p-4 rounded-lg shadow-sm">
-            <div className="text-sm text-gray-500">ทุนที่มีงบประมาณ</div>
-            <div className="text-2xl font-semibold text-green-600">
-              {filteredFunds.reduce(
-                (sum, cat) =>
-                  sum +
-                  (cat.subcategories?.filter((s) => isAvailableResearch(s)).length || 0),
-                0
-              )}
-            </div>
-          </div>
-          <div className="bg-white p-4 rounded-lg shadow-sm">
-            <div className="text-sm text-gray-500">งบประมาณรวมคงเหลือ</div>
-            <div className="text-xl font-semibold text-blue-600">
-              {formatAmount(
-                filteredFunds.reduce(
-                  (sum, cat) =>
-                    sum +
-                    (cat.subcategories?.reduce(
-                      (subSum, sub) => subSum + (sub.remaining_budget || 0),
-                      0
-                    ) || 0),
-                  0
-                )
-              )}
-            </div>
-          </div>
-        </div>
-      )}
-
       {/* Funds Table (เหมือน Promotion) */}
       {filteredFunds.length === 0 ? (
         <div className="bg-white rounded-lg shadow-sm p-8 text-center">


### PR DESCRIPTION
## Summary
- remove the fund summary statistic cards from the promotion and research fund pages for both admin and member
- rename the promotion fund apply button for members to display "ยื่นขอทุน"

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e50045ba0883229774deed347a76df