### PR TITLE
Prevent stale data when refetching fund lists

### DIFF
--- a/frontend_project_fund/app/member/components/applications/ApplicationList.js
+++ b/frontend_project_fund/app/member/components/applications/ApplicationList.js
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { Search, Eye, Download, FileText, ClipboardList, Plus, RefreshCcw } from "lucide-react";
 import { submissionAPI, teacherAPI } from "@/app/lib/member_api";
 import { systemAPI } from "@/app/lib/api";
@@ -22,6 +22,7 @@ export default function ApplicationList({ onNavigate }) {
   const [loading, setLoading] = useState(false);
   const [years, setYears] = useState([]);
   const [yearsLoading, setYearsLoading] = useState(false);
+  const latestApplicationsRequestRef = useRef(0);
   const {
     statuses: statusOptions,
     getLabelById,
@@ -139,6 +140,7 @@ export default function ApplicationList({ onNavigate }) {
 
   // Load applications from API
   const loadApplications = async () => {
+    const requestId = ++latestApplicationsRequestRef.current;
     setLoading(true);
     try {
       // Build query params for API
@@ -171,7 +173,7 @@ export default function ApplicationList({ onNavigate }) {
       // Debug log
       console.log('API Response:', response);
 
-      if (response.success && response.submissions) {
+      if (response.success && Array.isArray(response.submissions)) {
         // Transform data to match existing structure
         const transformedData = response.submissions.map(sub => {
           const subId = getSubcategoryId(sub);
@@ -250,16 +252,25 @@ export default function ApplicationList({ onNavigate }) {
           return !(isApprovedLike || isClosedLike);
         });
 
-        setApplications(nonApprovedApplications);
-        setFilteredApplications(nonApprovedApplications);
+        if (latestApplicationsRequestRef.current === requestId) {
+          setApplications(nonApprovedApplications);
+          setFilteredApplications(nonApprovedApplications);
+        }
+      } else if (latestApplicationsRequestRef.current === requestId) {
+        setApplications([]);
+        setFilteredApplications([]);
       }
     } catch (error) {
       console.error('Error loading applications:', error);
       // Fallback to empty array
-      setApplications([]);
-      setFilteredApplications([]);
+      if (latestApplicationsRequestRef.current === requestId) {
+        setApplications([]);
+        setFilteredApplications([]);
+      }
     } finally {
-      setLoading(false);
+      if (latestApplicationsRequestRef.current === requestId) {
+        setLoading(false);
+      }
     }
   };
 
@@ -497,8 +508,8 @@ export default function ApplicationList({ onNavigate }) {
     }
   };
 
-  const handleRefresh = () => {
-    loadApplications();
+  const handleRefresh = async () => {
+    await loadApplications();
   };
 
   return (

--- a/frontend_project_fund/app/member/components/funds/ReceivedFundsList.js
+++ b/frontend_project_fund/app/member/components/funds/ReceivedFundsList.js
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Search, Eye, Download, Gift, RefreshCcw } from "lucide-react";
 import { submissionAPI, teacherAPI } from "@/app/lib/member_api";
 import { systemAPI } from "@/app/lib/api";
@@ -22,6 +22,7 @@ export default function ReceivedFundsList({ onNavigate }) {
   const [loading, setLoading] = useState(false);
   const [years, setYears] = useState([]);
   const [yearsLoading, setYearsLoading] = useState(false);
+  const latestFundsRequestRef = useRef(0);
   const {
     statuses: statusOptions,
     getLabelById,
@@ -98,8 +99,8 @@ export default function ReceivedFundsList({ onNavigate }) {
     }
   };
 
-  const handleRefresh = () => {
-    loadFunds();
+  const handleRefresh = async () => {
+    await loadFunds();
   };
 
   const findYearIdByLabel = (label) => {
@@ -141,6 +142,7 @@ export default function ReceivedFundsList({ onNavigate }) {
   };
 
   const loadFunds = async () => {
+    const requestId = ++latestFundsRequestRef.current;
     setLoading(true);
     try {
       const params = { limit: 1000 };
@@ -227,18 +229,24 @@ export default function ReceivedFundsList({ onNavigate }) {
             new Date(a._original?.created_at || a._original?.create_at || 0)
         );
 
-        setFunds(approvedOrClosed);
-        setFilteredFunds(approvedOrClosed);
-      } else {
+        if (latestFundsRequestRef.current === requestId) {
+          setFunds(approvedOrClosed);
+          setFilteredFunds(approvedOrClosed);
+        }
+      } else if (latestFundsRequestRef.current === requestId) {
         setFunds([]);
         setFilteredFunds([]);
       }
     } catch (error) {
       console.error("Error loading received funds:", error);
-      setFunds([]);
-      setFilteredFunds([]);
+      if (latestFundsRequestRef.current === requestId) {
+        setFunds([]);
+        setFilteredFunds([]);
+      }
     } finally {
-      setLoading(false);
+      if (latestFundsRequestRef.current === requestId) {
+        setLoading(false);
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- guard application and received funds tables against stale responses by tracking the latest async request
- only update loading indicators and table data when the newest fetch finishes and make refresh actions await the current load

## Testing
- npm run lint *(fails: prompts for initial ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68e530c558b4832299df67ce137a550e