### PR TITLE
Fix attachment names in admin and department detail pages

### DIFF
--- a/frontend_project_fund/app/admin/components/submissions/GeneralSubmissionDetails.js
+++ b/frontend_project_fund/app/admin/components/submissions/GeneralSubmissionDetails.js
@@ -22,6 +22,7 @@ import 'sweetalert2/dist/sweetalert2.min.css';
 import { PDFDocument } from 'pdf-lib';
 import { AnimatePresence, motion } from 'motion/react';
 import PublicationSubmissionDetails from './PublicationSubmissionDetails';
+import { resolveDocumentFileName } from '@/app/utils/fileHelpers';
 
 /* =========================
  * Helpers
@@ -948,14 +949,7 @@ export default function GeneralSubmissionDetails({ submissionId, onBack }) {
 
         const merged = (rawDocs || []).map((d, i) => {
           const fileId = d.file_id ?? d.File?.file_id ?? d.file?.file_id ?? d.id;
-          const name =
-            d.file_name ??
-            d.original_name ??
-            d.original_filename ??
-            d.File?.original_name ??
-            d.file?.original_name ??
-            d.name ??
-            `เอกสารที่ ${i + 1}`;
+          const name = resolveDocumentFileName(d, `เอกสารที่ ${i + 1}`);
           const docTypeId = d.document_type_id ?? d.DocumentTypeID ?? d.doc_type_id ?? null;
           const docTypeName = d.document_type_name || typeMap[String(docTypeId)] || 'ไม่ระบุหมวด';
           return {
@@ -1453,8 +1447,12 @@ export default function GeneralSubmissionDetails({ submissionId, onBack }) {
         const pages = await merged.copyPages(src, src.getPageIndices());
         pages.forEach((p) => merged.addPage(p));
       } catch (e) {
-        console.warn('merge: skip', e);
-        skipped.push(doc?.original_name || doc?.file_name || `file-${doc.file_id}.pdf`);
+        const skippedName = resolveDocumentFileName(
+          doc,
+          doc?.file_id ? `file-${doc.file_id}.pdf` : 'unknown-file'
+        );
+        console.warn('merge: skip', skippedName, e);
+        skipped.push(skippedName);
         continue;
       }
     }
@@ -1928,14 +1926,7 @@ export default function GeneralSubmissionDetails({ submissionId, onBack }) {
             <div className="space-y-4">
               {attachments.map((doc, index) => {
                 const fileId = doc.file_id || doc.File?.file_id || doc.file?.file_id;
-                const fileName =
-                  doc.original_name ||
-                  doc.File?.original_name ||
-                  doc.file?.original_name ||
-                  doc.original_filename ||
-                  doc.file_name ||
-                  doc.name ||
-                  `เอกสารที่ ${index + 1}`;
+                const fileName = resolveDocumentFileName(doc, `เอกสารที่ ${index + 1}`);
                 const docType = (doc.document_type_name || '').trim() || 'ไม่ระบุประเภท';
 
                 return (

--- a/frontend_project_fund/app/admin/components/submissions/PublicationSubmissionDetails.js
+++ b/frontend_project_fund/app/admin/components/submissions/PublicationSubmissionDetails.js
@@ -36,6 +36,7 @@ import { adminSubmissionAPI } from '@/app/lib/admin_submission_api';
 import { rewardConfigAPI } from '@/app/lib/publication_api';
 import adminAPI from '@/app/lib/admin_api';
 import { notificationsAPI } from '@/app/lib/notifications_api';
+import { resolveDocumentFileName } from '@/app/utils/fileHelpers';
 
 import Swal from 'sweetalert2';
 import 'sweetalert2/dist/sweetalert2.min.css';
@@ -1214,14 +1215,7 @@ export default function PublicationSubmissionDetails({ submissionId, onBack }) {
 
         const merged = rawDocs.map((d, i) => {
           const fileId = d.file_id ?? d.File?.file_id ?? d.file?.file_id ?? d.id;
-          const name =
-            d.file_name ??
-            d.original_name ??
-            d.original_filename ??
-            d.File?.original_name ??
-            d.file?.original_name ??
-            d.name ??
-            `เอกสารที่ ${i + 1}`;
+          const name = resolveDocumentFileName(d, `เอกสารที่ ${i + 1}`);
 
           const docTypeId = d.document_type_id ?? d.DocumentTypeID ?? d.doc_type_id ?? null;
           const docTypeName =
@@ -1556,10 +1550,14 @@ export default function PublicationSubmissionDetails({ submissionId, onBack }) {
         const blob = await fetchFileAsBlob(doc.file_id);
         const src = await PDFDocument.load(await blob.arrayBuffer(), { ignoreEncryption: true });
         const pages = await merged.copyPages(src, src.getPageIndices());
-        pages.forEach(p => merged.addPage(p));
+        pages.forEach((p) => merged.addPage(p));
       } catch (e) {
-        console.warn('merge: skip', doc?.original_name || doc?.file_name || doc?.file_id, e);
-        skipped.push(doc?.original_name || doc?.file_name || `file-${doc.file_id}.pdf`);
+        const skippedName = resolveDocumentFileName(
+          doc,
+          doc?.file_id ? `file-${doc.file_id}.pdf` : 'unknown-file'
+        );
+        console.warn('merge: skip', skippedName, e);
+        skipped.push(skippedName);
         continue;
       }
     }
@@ -2290,14 +2288,7 @@ export default function PublicationSubmissionDetails({ submissionId, onBack }) {
               <div className="space-y-4">
                 {attachments.map((doc, index) => {
                   const fileId = doc.file_id || doc.File?.file_id || doc.file?.file_id;
-                  const fileName =
-                    doc.original_name ||
-                    doc.File?.original_name ||
-                    doc.file?.original_name ||
-                    doc.original_filename ||
-                    doc.file_name ||
-                    doc.name ||
-                    `เอกสารที่ ${index + 1}`;
+                  const fileName = resolveDocumentFileName(doc, `เอกสารที่ ${index + 1}`);
                   const docType = (doc.document_type_name || '').trim() || 'ไม่ระบุประเภท';
 
                   return (

--- a/frontend_project_fund/app/member/components/dept/details/GeneralSubmissionDetailsDept.js
+++ b/frontend_project_fund/app/member/components/dept/details/GeneralSubmissionDetailsDept.js
@@ -20,6 +20,7 @@ import { PDFDocument } from 'pdf-lib';
 import PublicationSubmissionDetailsDept from './PublicationSubmissionDetailsDept';
 import Swal from 'sweetalert2';
 import 'sweetalert2/dist/sweetalert2.min.css';
+import { resolveDocumentFileName } from '@/app/utils/fileHelpers';
 
 /* =========================
  * Helpers
@@ -833,26 +834,6 @@ export default function GeneralSubmissionDetailsDept({ submissionId, onBack }) {
     return null;
   };
 
-  const resolveFileName = (doc, fallback = 'document') => {
-    const candidates = [
-      doc?.original_name,
-      doc?.original_filename,
-      doc?.file_name,
-      doc?.File?.original_name,
-      doc?.file?.original_name,
-      doc?.File?.file_name,
-      doc?.file?.file_name,
-      doc?.name,
-      doc?.title,
-    ];
-    for (const candidate of candidates) {
-      if (typeof candidate === 'string' && candidate.trim() !== '') {
-        return candidate;
-      }
-    }
-    return fallback;
-  };
-
   const fetchManagedFileBlob = async (fileId) => {
     const token = apiClient.getToken();
     const url = `${apiClient.baseURL}/files/managed/${fileId}/download`;
@@ -948,7 +929,7 @@ export default function GeneralSubmissionDetailsDept({ submissionId, onBack }) {
     }
 
     const fileId = resolveFileId(doc);
-    const fileName = resolveFileName(doc, fallbackName);
+    const fileName = resolveDocumentFileName(doc, fallbackName);
 
     if (fileId != null) {
       try {
@@ -980,7 +961,10 @@ export default function GeneralSubmissionDetailsDept({ submissionId, onBack }) {
         const pages = await merged.copyPages(src, src.getPageIndices());
         pages.forEach((p) => merged.addPage(p));
       } catch (e) {
-        const skippedName = resolveFileName(doc, doc?.file_id ? `file-${doc.file_id}.pdf` : 'unknown.pdf');
+        const skippedName = resolveDocumentFileName(
+          doc,
+          doc?.file_id ? `file-${doc.file_id}.pdf` : 'unknown.pdf'
+        );
         console.warn('merge: skip', skippedName, e);
         skipped.push(skippedName);
         continue;
@@ -1222,14 +1206,7 @@ export default function GeneralSubmissionDetailsDept({ submissionId, onBack }) {
             <div className="space-y-4">
               {attachments.map((doc, index) => {
                 const fileId = doc.file_id || doc.File?.file_id || doc.file?.file_id;
-                const fileName =
-                  doc.original_name ||
-                  doc.File?.original_name ||
-                  doc.file?.original_name ||
-                  doc.original_filename ||
-                  doc.file_name ||
-                  doc.name ||
-                  `เอกสารที่ ${index + 1}`;
+                const fileName = resolveDocumentFileName(doc, `เอกสารที่ ${index + 1}`);
                 const docType = (doc.document_type_name || '').trim() || 'ไม่ระบุประเภท';
 
                 const canOpen = fileId != null || !!resolveFilePath(doc);

--- a/frontend_project_fund/app/member/components/dept/details/PublicationSubmissionDetailsDept.js
+++ b/frontend_project_fund/app/member/components/dept/details/PublicationSubmissionDetailsDept.js
@@ -37,6 +37,7 @@ import { notificationsAPI } from '@/app/lib/notifications_api';
 
 import Swal from 'sweetalert2';
 import 'sweetalert2/dist/sweetalert2.min.css';
+import { resolveDocumentFileName } from '@/app/utils/fileHelpers';
 
 const pickArray = (...candidates) => {
   for (const candidate of candidates) {
@@ -1153,26 +1154,6 @@ export default function PublicationSubmissionDetailsDept({ submissionId, onBack 
     return null;
   };
 
-  const resolveFileName = (doc, fallback = 'document') => {
-    const candidates = [
-      doc?.original_name,
-      doc?.original_filename,
-      doc?.file_name,
-      doc?.File?.original_name,
-      doc?.file?.original_name,
-      doc?.File?.file_name,
-      doc?.file?.file_name,
-      doc?.name,
-      doc?.title,
-    ];
-    for (const candidate of candidates) {
-      if (typeof candidate === 'string' && candidate.trim() !== '') {
-        return candidate;
-      }
-    }
-    return fallback;
-  };
-
   const fetchManagedFileBlob = async (fileId) => {
     const token = apiClient.getToken();
     const url = `${apiClient.baseURL}/files/managed/${fileId}/download`;
@@ -1268,7 +1249,7 @@ export default function PublicationSubmissionDetailsDept({ submissionId, onBack 
     }
 
     const fileId = resolveFileId(doc);
-    const fileName = resolveFileName(doc, fallbackName);
+    const fileName = resolveDocumentFileName(doc, fallbackName);
 
     if (fileId != null) {
       try {
@@ -1311,7 +1292,10 @@ export default function PublicationSubmissionDetailsDept({ submissionId, onBack 
         const pages = await merged.copyPages(src, src.getPageIndices());
         pages.forEach(p => merged.addPage(p));
       } catch (e) {
-        const skippedName = resolveFileName(doc, doc?.file_id ? `file-${doc.file_id}.pdf` : 'unknown.pdf');
+        const skippedName = resolveDocumentFileName(
+          doc,
+          doc?.file_id ? `file-${doc.file_id}.pdf` : 'unknown.pdf'
+        );
         console.warn('merge: skip', skippedName, e);
         skipped.push(skippedName);
         continue;
@@ -2098,7 +2082,7 @@ export default function PublicationSubmissionDetailsDept({ submissionId, onBack 
               <div className="space-y-4">
                 {attachments.map((doc, index) => {
                   const fileId = resolveFileId(doc);
-                  const fileName = resolveFileName(doc, `เอกสารที่ ${index + 1}`);
+                  const fileName = resolveDocumentFileName(doc, `เอกสารที่ ${index + 1}`);
                   const docType = (doc.document_type_name || '').trim() || 'ไม่ระบุประเภท';
                   const canOpen = fileId != null || !!resolveFilePath(doc);
 

--- a/frontend_project_fund/app/utils/fileHelpers.js
+++ b/frontend_project_fund/app/utils/fileHelpers.js
@@ -1,0 +1,77 @@
+// Utility helpers for resolving document/file metadata into display-friendly values.
+
+/**
+ * Attempt to resolve the most appropriate display name for an attachment/document.
+ * The backend payload contains the file name under various fields depending on
+ * the context (legacy APIs, new endpoints, nested managed file objects, etc.).
+ *
+ * This helper consolidates the different possibilities and returns the first
+ * non-empty string it can find. As a final fallback it tries to derive the name
+ * from any available path/URL before returning the provided fallback label.
+ *
+ * @param {object} doc - Document/attachment payload from the API.
+ * @param {string} fallback - Value used when no name could be derived.
+ * @returns {string}
+ */
+export function resolveDocumentFileName(doc, fallback = 'document') {
+  const firstString = (candidates) => {
+    for (const candidate of candidates) {
+      if (typeof candidate === 'string') {
+        const trimmed = candidate.trim();
+        if (trimmed) {
+          return trimmed;
+        }
+      }
+    }
+    return null;
+  };
+
+  const directName = firstString([
+    doc?.original_name,
+    doc?.original_filename,
+    doc?.filename,
+    doc?.file_name,
+    doc?.display_name,
+    doc?.name,
+    doc?.title,
+    doc?.document_name,
+    doc?.document_title,
+    doc?.File?.original_name,
+    doc?.File?.original_filename,
+    doc?.File?.filename,
+    doc?.File?.file_name,
+    doc?.File?.display_name,
+    doc?.file?.original_name,
+    doc?.file?.original_filename,
+    doc?.file?.filename,
+    doc?.file?.file_name,
+    doc?.file?.display_name,
+    doc?.Document?.original_name,
+    doc?.Document?.original_filename,
+  ]);
+
+  if (directName) return directName;
+
+  const pathCandidate = firstString([
+    doc?.file_path,
+    doc?.File?.file_path,
+    doc?.file?.file_path,
+    doc?.path,
+    doc?.File?.path,
+    doc?.file?.path,
+    doc?.file_url,
+    doc?.url,
+    doc?.File?.url,
+    doc?.file?.url,
+  ]);
+
+  if (pathCandidate) {
+    const segments = pathCandidate.split(/[\\/]/).filter(Boolean);
+    if (segments.length > 0) {
+      return segments[segments.length - 1];
+    }
+  }
+
+  return fallback;
+}
+


### PR DESCRIPTION
## Summary
- add a shared helper to resolve attachment file names from API payloads and paths
- use the helper in admin submission detail views to show friendly attachment names and log merge skips
- switch department general and publication detail pages to the helper for display, download, and PDF merge fallbacks

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e57a14eae0832aba8b2eb9b13eb443