### PR TITLE
Fix attachment file names for member and admin detail pages

### DIFF
--- a/frontend_project_fund/app/admin/components/submissions/GeneralSubmissionDetails.js
+++ b/frontend_project_fund/app/admin/components/submissions/GeneralSubmissionDetails.js
@@ -78,6 +78,31 @@ const getUserFullName = (u) => {
   return name || (u.email || '-');
 };
 
+const resolveDocumentName = (doc, fallback = 'document') => {
+  const candidates = [
+    doc?.original_name,
+    doc?.original_filename,
+    doc?.file_name,
+    doc?.File?.original_name,
+    doc?.file?.original_name,
+    doc?.File?.file_name,
+    doc?.file?.file_name,
+    doc?.name,
+    doc?.title,
+  ];
+
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string') {
+      const trimmed = candidate.trim();
+      if (trimmed !== '') {
+        return trimmed;
+      }
+    }
+  }
+
+  return fallback;
+};
+
 // format "0฿" (suffix)
 function baht(value) {
   const n = Number(value ?? 0);
@@ -948,14 +973,7 @@ export default function GeneralSubmissionDetails({ submissionId, onBack }) {
 
         const merged = (rawDocs || []).map((d, i) => {
           const fileId = d.file_id ?? d.File?.file_id ?? d.file?.file_id ?? d.id;
-          const name =
-            d.file_name ??
-            d.original_name ??
-            d.original_filename ??
-            d.File?.original_name ??
-            d.file?.original_name ??
-            d.name ??
-            `เอกสารที่ ${i + 1}`;
+          const name = resolveDocumentName(d, `เอกสารที่ ${i + 1}`);
           const docTypeId = d.document_type_id ?? d.DocumentTypeID ?? d.doc_type_id ?? null;
           const docTypeName = d.document_type_name || typeMap[String(docTypeId)] || 'ไม่ระบุหมวด';
           return {
@@ -1928,14 +1946,7 @@ export default function GeneralSubmissionDetails({ submissionId, onBack }) {
             <div className="space-y-4">
               {attachments.map((doc, index) => {
                 const fileId = doc.file_id || doc.File?.file_id || doc.file?.file_id;
-                const fileName =
-                  doc.original_name ||
-                  doc.File?.original_name ||
-                  doc.file?.original_name ||
-                  doc.original_filename ||
-                  doc.file_name ||
-                  doc.name ||
-                  `เอกสารที่ ${index + 1}`;
+                const fileName = resolveDocumentName(doc, `เอกสารที่ ${index + 1}`);
                 const docType = (doc.document_type_name || '').trim() || 'ไม่ระบุประเภท';
 
                 return (

--- a/frontend_project_fund/app/admin/components/submissions/PublicationSubmissionDetails.js
+++ b/frontend_project_fund/app/admin/components/submissions/PublicationSubmissionDetails.js
@@ -78,6 +78,31 @@ const getColoredStatusIcon = (statusCode) => {
   };
 };
 
+const resolveDocumentName = (doc, fallback = 'document') => {
+  const candidates = [
+    doc?.original_name,
+    doc?.original_filename,
+    doc?.file_name,
+    doc?.File?.original_name,
+    doc?.file?.original_name,
+    doc?.File?.file_name,
+    doc?.file?.file_name,
+    doc?.name,
+    doc?.title,
+  ];
+
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string') {
+      const trimmed = candidate.trim();
+      if (trimmed !== '') {
+        return trimmed;
+      }
+    }
+  }
+
+  return fallback;
+};
+
 
 const formatDate = (dateString) => {
   if (!dateString) return '-';
@@ -1214,14 +1239,7 @@ export default function PublicationSubmissionDetails({ submissionId, onBack }) {
 
         const merged = rawDocs.map((d, i) => {
           const fileId = d.file_id ?? d.File?.file_id ?? d.file?.file_id ?? d.id;
-          const name =
-            d.file_name ??
-            d.original_name ??
-            d.original_filename ??
-            d.File?.original_name ??
-            d.file?.original_name ??
-            d.name ??
-            `เอกสารที่ ${i + 1}`;
+          const name = resolveDocumentName(d, `เอกสารที่ ${i + 1}`);
 
           const docTypeId = d.document_type_id ?? d.DocumentTypeID ?? d.doc_type_id ?? null;
           const docTypeName =
@@ -2290,14 +2308,7 @@ export default function PublicationSubmissionDetails({ submissionId, onBack }) {
               <div className="space-y-4">
                 {attachments.map((doc, index) => {
                   const fileId = doc.file_id || doc.File?.file_id || doc.file?.file_id;
-                  const fileName =
-                    doc.original_name ||
-                    doc.File?.original_name ||
-                    doc.file?.original_name ||
-                    doc.original_filename ||
-                    doc.file_name ||
-                    doc.name ||
-                    `เอกสารที่ ${index + 1}`;
+                  const fileName = resolveDocumentName(doc, `เอกสารที่ ${index + 1}`);
                   const docType = (doc.document_type_name || '').trim() || 'ไม่ระบุประเภท';
 
                   return (

--- a/frontend_project_fund/app/member/components/dept/details/GeneralSubmissionDetailsDept.js
+++ b/frontend_project_fund/app/member/components/dept/details/GeneralSubmissionDetailsDept.js
@@ -98,6 +98,31 @@ const getUserFullName = (u) => {
   return name || (u.email || '-');
 };
 
+const resolveDocumentName = (doc, fallback = 'document') => {
+  const candidates = [
+    doc?.original_name,
+    doc?.original_filename,
+    doc?.file_name,
+    doc?.File?.original_name,
+    doc?.file?.original_name,
+    doc?.File?.file_name,
+    doc?.file?.file_name,
+    doc?.name,
+    doc?.title,
+  ];
+
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string') {
+      const trimmed = candidate.trim();
+      if (trimmed !== '') {
+        return trimmed;
+      }
+    }
+  }
+
+  return fallback;
+};
+
 // format THB
 function baht(value) {
   const n = Number(value ?? 0);
@@ -517,14 +542,7 @@ export default function GeneralSubmissionDetailsDept({ submissionId, onBack }) {
 
         const merged = (rawDocs || []).map((d, i) => {
           const fileId = d.file_id ?? d.File?.file_id ?? d.file?.file_id ?? d.id;
-          const name =
-            d.file_name ??
-            d.original_name ??
-            d.original_filename ??
-            d.File?.original_name ??
-            d.file?.original_name ??
-            d.name ??
-            `เอกสารที่ ${i + 1}`;
+          const name = resolveDocumentName(d, `เอกสารที่ ${i + 1}`);
           const docTypeId = d.document_type_id ?? d.DocumentTypeID ?? d.doc_type_id ?? null;
           const docTypeName = d.document_type_name || typeMap[String(docTypeId)] || 'ไม่ระบุหมวด';
           return {
@@ -833,25 +851,8 @@ export default function GeneralSubmissionDetailsDept({ submissionId, onBack }) {
     return null;
   };
 
-  const resolveFileName = (doc, fallback = 'document') => {
-    const candidates = [
-      doc?.original_name,
-      doc?.original_filename,
-      doc?.file_name,
-      doc?.File?.original_name,
-      doc?.file?.original_name,
-      doc?.File?.file_name,
-      doc?.file?.file_name,
-      doc?.name,
-      doc?.title,
-    ];
-    for (const candidate of candidates) {
-      if (typeof candidate === 'string' && candidate.trim() !== '') {
-        return candidate;
-      }
-    }
-    return fallback;
-  };
+  const resolveFileName = (doc, fallback = 'document') =>
+    resolveDocumentName(doc, fallback);
 
   const fetchManagedFileBlob = async (fileId) => {
     const token = apiClient.getToken();
@@ -1222,14 +1223,7 @@ export default function GeneralSubmissionDetailsDept({ submissionId, onBack }) {
             <div className="space-y-4">
               {attachments.map((doc, index) => {
                 const fileId = doc.file_id || doc.File?.file_id || doc.file?.file_id;
-                const fileName =
-                  doc.original_name ||
-                  doc.File?.original_name ||
-                  doc.file?.original_name ||
-                  doc.original_filename ||
-                  doc.file_name ||
-                  doc.name ||
-                  `เอกสารที่ ${index + 1}`;
+                const fileName = resolveDocumentName(doc, `เอกสารที่ ${index + 1}`);
                 const docType = (doc.document_type_name || '').trim() || 'ไม่ระบุประเภท';
 
                 const canOpen = fileId != null || !!resolveFilePath(doc);

--- a/frontend_project_fund/app/member/components/dept/details/PublicationSubmissionDetailsDept.js
+++ b/frontend_project_fund/app/member/components/dept/details/PublicationSubmissionDetailsDept.js
@@ -133,6 +133,31 @@ const firstNonEmpty = (...vals) => {
   return null;
 };
 
+const resolveDocumentName = (doc, fallback = 'document') => {
+  const candidates = [
+    doc?.original_name,
+    doc?.original_filename,
+    doc?.file_name,
+    doc?.File?.original_name,
+    doc?.file?.original_name,
+    doc?.File?.file_name,
+    doc?.file?.file_name,
+    doc?.name,
+    doc?.title,
+  ];
+
+  for (const candidate of candidates) {
+    if (typeof candidate === 'string') {
+      const trimmed = candidate.trim();
+      if (trimmed !== '') {
+        return trimmed;
+      }
+    }
+  }
+
+  return fallback;
+};
+
 const getSubcategoryName = (submission, pubDetail) => {
   // 1) จากรายละเอียดบทความ (ลองหลายชื่อ key)
   const fromDetail = firstNonEmpty(
@@ -961,6 +986,7 @@ export default function PublicationSubmissionDetailsDept({ submissionId, onBack 
             ...d,
             document_type_id: docTypeId ?? d?.document_type_id ?? null,
             document_type_name: docTypeName,
+            original_name: resolveDocumentName(d, `เอกสารที่ ${index + 1}`),
             _index: index,
           };
         });
@@ -1153,25 +1179,8 @@ export default function PublicationSubmissionDetailsDept({ submissionId, onBack 
     return null;
   };
 
-  const resolveFileName = (doc, fallback = 'document') => {
-    const candidates = [
-      doc?.original_name,
-      doc?.original_filename,
-      doc?.file_name,
-      doc?.File?.original_name,
-      doc?.file?.original_name,
-      doc?.File?.file_name,
-      doc?.file?.file_name,
-      doc?.name,
-      doc?.title,
-    ];
-    for (const candidate of candidates) {
-      if (typeof candidate === 'string' && candidate.trim() !== '') {
-        return candidate;
-      }
-    }
-    return fallback;
-  };
+  const resolveFileName = (doc, fallback = 'document') =>
+    resolveDocumentName(doc, fallback);
 
   const fetchManagedFileBlob = async (fileId) => {
     const token = apiClient.getToken();

--- a/frontend_project_fund/app/member/components/funds/FundApplicationDetail.js
+++ b/frontend_project_fund/app/member/components/funds/FundApplicationDetail.js
@@ -60,6 +60,31 @@ const getColoredStatusIcon = (statusCode) => {
   };
 };
 
+const resolveDocumentName = (doc, fallback = "document") => {
+  const candidates = [
+    doc?.original_name,
+    doc?.original_filename,
+    doc?.file_name,
+    doc?.File?.original_name,
+    doc?.file?.original_name,
+    doc?.File?.file_name,
+    doc?.file?.file_name,
+    doc?.name,
+    doc?.title,
+  ];
+
+  for (const candidate of candidates) {
+    if (typeof candidate === "string") {
+      const trimmed = candidate.trim();
+      if (trimmed !== "") {
+        return trimmed;
+      }
+    }
+  }
+
+  return fallback;
+};
+
 export default function FundApplicationDetail({ submissionId, onNavigate }) {
   const [submission, setSubmission] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -492,13 +517,7 @@ export default function FundApplicationDetail({ submissionId, onNavigate }) {
                 <tbody className="bg-white divide-y divide-gray-200">
                   {documents.map((doc, index) => {
                     const fileId = doc.file_id || doc.File?.file_id || doc.file?.file_id;
-                    const docName =
-                      doc.File?.original_name ||
-                      doc.file?.original_name ||
-                      doc.original_filename ||
-                      doc.file_name ||
-                      doc.name ||
-                      `เอกสารที่ ${index + 1}`;
+                    const docName = resolveDocumentName(doc, `เอกสารที่ ${index + 1}`);
                     const docType =
                       doc.document_type_name && doc.document_type_name.trim() !== ""
                         ? doc.document_type_name

--- a/frontend_project_fund/app/member/components/funds/PublicationRewardDetail.js
+++ b/frontend_project_fund/app/member/components/funds/PublicationRewardDetail.js
@@ -96,6 +96,31 @@ const firstNonEmpty = (...vals) => {
   return null;
 };
 
+const resolveDocumentName = (doc, fallback = "document") => {
+  const candidates = [
+    doc?.original_name,
+    doc?.original_filename,
+    doc?.file_name,
+    doc?.File?.original_name,
+    doc?.file?.original_name,
+    doc?.File?.file_name,
+    doc?.file?.file_name,
+    doc?.name,
+    doc?.title,
+  ];
+
+  for (const candidate of candidates) {
+    if (typeof candidate === "string") {
+      const trimmed = candidate.trim();
+      if (trimmed !== "") {
+        return trimmed;
+      }
+    }
+  }
+
+  return fallback;
+};
+
 const getSubcategoryName = (submission, pubDetail) => {
   const fromDetail = firstNonEmpty(
     pubDetail?.subcategory_name_th,
@@ -1098,7 +1123,7 @@ export default function PublicationRewardDetail({ submissionId, onNavigate }) {
                   <tbody className="bg-white divide-y divide-gray-200">
                     {documents.map((doc, index) => {
                       const fileId = doc.file_id || doc.File?.file_id || doc.file?.file_id;
-                      const docName = doc.File?.original_name || doc.file?.original_name || doc.original_filename || doc.file_name || doc.name || `เอกสารที่ ${index + 1}`;
+                      const docName = resolveDocumentName(doc, `เอกสารที่ ${index + 1}`);
                       const docType =
                         doc.document_type_name && doc.document_type_name.trim() !== ""
                           ? doc.document_type_name


### PR DESCRIPTION
## Summary
- use a shared resolver to read attachment names from API metadata on the member fund application and publication reward detail pages
- update the department head submission views to reuse the resolver and persist resolved names when normalising attachment payloads
- apply the same resolver on the admin submission detail pages and confirmed that the backend enrichment already supplies the file metadata

## Testing
- npm --prefix frontend_project_fund run lint *(fails: command enters interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68e58a95e220832aa05a5c8cfd57a187