### PR TITLE
Use submission numbers for submission storage folders

### DIFF
--- a/fund-management-api/controllers/admin_submission.go
+++ b/fund-management-api/controllers/admin_submission.go
@@ -927,7 +927,7 @@ func CreateResearchFundEvent(c *gin.Context) {
 		if err != nil {
 			return err
 		}
-		submissionFolderPath, err := utils.CreateSubmissionFolder(userFolderPath, submission.SubmissionType, submission.SubmissionID, submission.CreatedAt)
+		submissionFolderPath, err := utils.CreateSubmissionFolder(userFolderPath, submission.SubmissionType, submission.SubmissionNumber, submission.SubmissionID, submission.CreatedAt)
 		if err != nil {
 			return err
 		}

--- a/fund-management-api/controllers/dept_head_submission.go
+++ b/fund-management-api/controllers/dept_head_submission.go
@@ -488,7 +488,7 @@ func regenerateHeadApprovedPublicationDoc(tx *gorm.DB, submission *models.Submis
 		return fmt.Errorf("failed to prepare user directory: %w", err)
 	}
 
-	submissionFolderPath, err := utils.CreateSubmissionFolder(userFolderPath, submission.SubmissionType, submission.SubmissionID, submission.CreatedAt)
+	submissionFolderPath, err := utils.CreateSubmissionFolder(userFolderPath, submission.SubmissionType, submission.SubmissionNumber, submission.SubmissionID, submission.CreatedAt)
 	if err != nil {
 		return fmt.Errorf("failed to prepare submission folder: %w", err)
 	}

--- a/fund-management-api/controllers/document.go
+++ b/fund-management-api/controllers/document.go
@@ -97,9 +97,14 @@ func UploadDocument(c *gin.Context) {
 	// Convert applicationID to int
 	appID, _ := strconv.Atoi(applicationID)
 
+	createdAt := time.Now()
+	if application.CreateAt != nil {
+		createdAt = *application.CreateAt
+	}
+
 	// Create submission folder for this application
 	submissionFolderPath, err := utils.CreateSubmissionFolder(
-		userFolderPath, "fund", appID, time.Now())
+		userFolderPath, "fund_application", application.ApplicationNumber, appID, createdAt)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create submission directory"})
 		return

--- a/fund-management-api/controllers/publication.go
+++ b/fund-management-api/controllers/publication.go
@@ -396,9 +396,14 @@ func CreatePublicationReward(c *gin.Context) {
 		return
 	}
 
+	createdAt := now
+	if reward.CreateAt != nil {
+		createdAt = *reward.CreateAt
+	}
+
 	// สร้าง submission folder
 	submissionFolderPath, err := utils.CreateSubmissionFolder(
-		userFolderPath, "publication", reward.RewardID, time.Now())
+		userFolderPath, "publication_reward", reward.RewardNumber, reward.RewardID, createdAt)
 	if err != nil {
 		tx.Rollback()
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create submission directory"})
@@ -806,9 +811,14 @@ func UploadPublicationDocument(c *gin.Context) {
 		return
 	}
 
+	createdAt := time.Now()
+	if reward.CreateAt != nil {
+		createdAt = *reward.CreateAt
+	}
+
 	// Create publication submission folder
 	submissionFolderPath, err := utils.CreateSubmissionFolder(
-		userFolderPath, "publication", reward.RewardID, time.Now())
+		userFolderPath, "publication_reward", reward.RewardNumber, reward.RewardID, createdAt)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create submission directory"})
 		return

--- a/fund-management-api/controllers/submission.go
+++ b/fund-management-api/controllers/submission.go
@@ -495,7 +495,7 @@ func SubmitSubmission(c *gin.Context) {
 			return fmt.Errorf("failed to prepare user directory: %w", err)
 		}
 
-		submissionFolderPath, err := utils.CreateSubmissionFolder(userFolderPath, submission.SubmissionType, submission.SubmissionID, submission.CreatedAt)
+		submissionFolderPath, err := utils.CreateSubmissionFolder(userFolderPath, submission.SubmissionType, submission.SubmissionNumber, submission.SubmissionID, submission.CreatedAt)
 		if err != nil {
 			return fmt.Errorf("failed to prepare submission folder: %w", err)
 		}
@@ -876,7 +876,7 @@ func MoveFileToSubmissionFolder(fileID int, submissionID int, submissionType str
 	}
 
 	submissionFolderPath, err := utils.CreateSubmissionFolder(
-		userFolderPath, submissionType, submissionID, submission.CreatedAt)
+		userFolderPath, submissionType, submission.SubmissionNumber, submissionID, submission.CreatedAt)
 	if err != nil {
 		return err
 	}

--- a/fund-management-api/utils/file_helper.go
+++ b/fund-management-api/utils/file_helper.go
@@ -40,19 +40,24 @@ func CreateUserFolderIfNotExists(user models.User, uploadPath string) (string, e
 }
 
 // CreateSubmissionFolder สร้างโฟลเดอร์ submission
-func CreateSubmissionFolder(userFolderPath string, submissionType string, submissionID int, createdDate time.Time) (string, error) {
-	// สร้างชื่อโฟลเดอร์: {type}{id}_{YYYY-MM-DD}
-	dateStr := createdDate.Format("2006-01-02")
+func CreateSubmissionFolder(userFolderPath string, submissionType string, submissionNumber string, submissionID int, createdDate time.Time) (string, error) {
+	// หากมี submission number ให้ใช้เป็นชื่อโฟลเดอร์โดยตรง (sanitize เพื่อความปลอดภัย)
 	var folderName string
+	if trimmed := strings.TrimSpace(submissionNumber); trimmed != "" {
+		folderName = SanitizeForFilename(trimmed)
+	}
 
-	// กำหนดชื่อตามประเภท
-	switch submissionType {
-	case "fund_application":
-		folderName = fmt.Sprintf("fund%d_%s", submissionID, dateStr)
-	case "publication_reward":
-		folderName = fmt.Sprintf("pub%d_%s", submissionID, dateStr)
-	default:
-		folderName = fmt.Sprintf("sub%d_%s", submissionID, dateStr)
+	// fallback กรณีไม่มี submission number (รองรับเคสระบบเก่า)
+	if folderName == "" {
+		dateStr := createdDate.Format("2006-01-02")
+		switch submissionType {
+		case "fund_application", "fund":
+			folderName = fmt.Sprintf("fund%d_%s", submissionID, dateStr)
+		case "publication_reward", "publication":
+			folderName = fmt.Sprintf("pub%d_%s", submissionID, dateStr)
+		default:
+			folderName = fmt.Sprintf("sub%d_%s", submissionID, dateStr)
+		}
 	}
 
 	submissionPath := filepath.Join(userFolderPath, "submissions", folderName)


### PR DESCRIPTION
## Summary
- update submission folder creation to prefer sanitized submission numbers with fallbacks for legacy records
- propagate submission numbers through submission, admin, and department head flows when preparing document directories
- ensure fund application and publication reward uploads derive folder timestamps from stored creation metadata

## Testing
- go test ./... *(fails: hangs waiting for external dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e62c49cc1c8322a4e345fe991f2128