### PR TITLE
Fix fund listings for updated category IDs

### DIFF
--- a/frontend_project_fund/app/admin/components/funds/PromotionFundContent.js
+++ b/frontend_project_fund/app/admin/components/funds/PromotionFundContent.js
@@ -8,6 +8,26 @@ import { teacherAPI } from "../../../lib/member_api";
 import { targetRolesUtils, filterFundsByRole } from "../../../lib/target_roles_utils";
 import systemConfigAPI from "../../../lib/system_config_api";
 
+const isPromotionCategory = (category) => {
+  const rawName =
+    category?.category_name ??
+    category?.categoryName ??
+    category?.name ??
+    "";
+  const name = String(rawName).trim().toLowerCase();
+  const categoryId = Number.parseInt(category?.category_id, 10);
+
+  if (!Number.isNaN(categoryId) && (categoryId === 2 || categoryId === 16)) {
+    return true;
+  }
+
+  return (
+    name.includes("ทุนอุดหนุนกิจกรรม") ||
+    name.includes("กิจกรรมส่งเสริม") ||
+    name.includes("promotion")
+  );
+};
+
 export default function PromotionFundContent() {
   const [selectedYear, setSelectedYear] = useState("2568");
   const [fundCategories, setFundCategories] = useState([]);
@@ -320,7 +340,7 @@ export default function PromotionFundContent() {
           );
 
       const promotionFunds = visibleCategories
-        .filter((category) => category.category_id === 2)
+        .filter(isPromotionCategory)
         .map((category) => ({
           ...category,
           subcategories: category.subcategories?.map(normalizeSubcategoryBudgets) || [],

--- a/frontend_project_fund/app/admin/components/funds/ResearchFundContent.js
+++ b/frontend_project_fund/app/admin/components/funds/ResearchFundContent.js
@@ -11,6 +11,26 @@ import {
 import systemConfigAPI from "../../../lib/system_config_api";
 import apiClient from "../../../lib/api";
 
+const isResearchCategory = (category) => {
+  const rawName =
+    category?.category_name ??
+    category?.categoryName ??
+    category?.name ??
+    "";
+  const name = String(rawName).trim().toLowerCase();
+  const categoryId = Number.parseInt(category?.category_id, 10);
+
+  if (!Number.isNaN(categoryId) && (categoryId === 1 || categoryId === 15)) {
+    return true;
+  }
+
+  return (
+    name.includes("ทุนส่งเสริมการวิจัย") ||
+    name.includes("วิจัยและนวัตกรรม") ||
+    name.includes("research")
+  );
+};
+
 export default function ResearchFundContent() {
   const [selectedYear, setSelectedYear] = useState("2568");
   const [fundCategories, setFundCategories] = useState([]);
@@ -273,9 +293,7 @@ export default function ResearchFundContent() {
         roleContext?.role_id ?? roleContext?.role_name ?? roleContext
       );
 
-      const researchFunds = visibleCategories.filter(
-        (category) => category.category_id === 1
-      );
+      const researchFunds = visibleCategories.filter(isResearchCategory);
 
       const adjusted = researchFunds.map((category) => {
         const updatedSubs = (category.subcategories || []).map((sub) => {

--- a/frontend_project_fund/app/member/components/funds/PromotionFundContent.js
+++ b/frontend_project_fund/app/member/components/funds/PromotionFundContent.js
@@ -9,6 +9,26 @@ import { targetRolesUtils, filterFundsByRole } from '../../../lib/target_roles_u
 import { FORM_TYPE_CONFIG } from '../../../lib/form_type_config';
 import systemConfigAPI from '../../../lib/system_config_api';
 
+const isPromotionCategory = (category) => {
+  const rawName =
+    category?.category_name ??
+    category?.categoryName ??
+    category?.name ??
+    '';
+  const name = String(rawName).trim().toLowerCase();
+  const categoryId = Number.parseInt(category?.category_id, 10);
+
+  if (!Number.isNaN(categoryId) && (categoryId === 2 || categoryId === 16)) {
+    return true;
+  }
+
+  return (
+    name.includes('ทุนอุดหนุนกิจกรรม') ||
+    name.includes('กิจกรรมส่งเสริม') ||
+    name.includes('promotion')
+  );
+};
+
 export default function PromotionFundContent({ onNavigate }) {
   const [selectedYear, setSelectedYear] = useState("2568");
   const [fundCategories, setFundCategories] = useState([]);
@@ -298,10 +318,8 @@ export default function PromotionFundContent({ onNavigate }) {
         roleContext?.role_id ?? roleContext?.role_name ?? roleContext
       );
 
-      // กรองเฉพาะทุนอุดหนุนกิจกรรม (category_id = 2)
-      const promotionFunds = visibleCategories.filter(
-        (category) => category.category_id === 2
-      );
+      // กรองเฉพาะทุนอุดหนุนกิจกรรม (รองรับรหัส/ชื่อใหม่)
+      const promotionFunds = visibleCategories.filter(isPromotionCategory);
 
       // รวมทุน publication_reward ให้เป็น 1 แถว (คงพฤติกรรมเดิม)
       const mergedPromotionFunds = promotionFunds.map((category) => {

--- a/frontend_project_fund/app/member/components/funds/ResearchFundContent.js
+++ b/frontend_project_fund/app/member/components/funds/ResearchFundContent.js
@@ -12,6 +12,26 @@ import { FORM_TYPE_CONFIG } from "../../../lib/form_type_config";
 import systemConfigAPI from "../../../lib/system_config_api";
 import apiClient from "../../../lib/api";
 
+const isResearchCategory = (category) => {
+  const rawName =
+    category?.category_name ??
+    category?.categoryName ??
+    category?.name ??
+    "";
+  const name = String(rawName).trim().toLowerCase();
+  const categoryId = Number.parseInt(category?.category_id, 10);
+
+  if (!Number.isNaN(categoryId) && (categoryId === 1 || categoryId === 15)) {
+    return true;
+  }
+
+  return (
+    name.includes("ทุนส่งเสริมการวิจัย") ||
+    name.includes("วิจัยและนวัตกรรม") ||
+    name.includes("research")
+  );
+};
+
 export default function ResearchFundContent({ onNavigate }) {
   const [selectedYear, setSelectedYear] = useState("2568");
   const [yearId, setYearId] = useState(null);
@@ -291,8 +311,8 @@ export default function ResearchFundContent({ onNavigate }) {
         roleContext?.role_id ?? roleContext?.role_name ?? roleContext
       );
 
-      // keep: research category only (category_id = 1)
-      const researchFunds = visibleCategories.filter((category) => category.category_id === 1);
+      // keep: research category only (support legacy + new IDs & names)
+      const researchFunds = visibleCategories.filter(isResearchCategory);
 
       // ถ้าอยู่นอกช่วงเวลา ให้เติม “สิ้นสุดรับคำขอ: …” ต่อท้าย fund_condition (เหมือน Promotion)
       const adjusted = researchFunds.map((category) => {


### PR DESCRIPTION
## Summary
- add category name helpers so research fund pages recognize the new dataset IDs
- update promotion fund listings to match both legacy and current category identifiers
- keep both admin and member views aligned by reusing the helper filters

## Testing
- not run (interactive `npm run lint` prompts for ESLint config)

------
https://chatgpt.com/codex/tasks/task_e_68e64cfed40c8322b700d2d4bf66d60c