### PR TITLE
Prefer new effective_announcement_id keys when normalizing system-config slots

### DIFF
--- a/frontend_project_fund/app/lib/system_config_api.js
+++ b/frontend_project_fund/app/lib/system_config_api.js
@@ -58,27 +58,27 @@ const SLOT_TIME_KEYS = {
   main: {
     start: ["main_start_date", "main_announcement_start", "main_annoucement_start", "main_start_at"],
     end: ["main_end_date", "main_announcement_end", "main_annoucement_end", "main_end_at"],
-    id: ["main_annoucement", "main_announcement", "main_ann_id"],
+    id: ["main_effective_announcement_id", "main_annoucement", "main_announcement", "main_ann_id"],
   },
   reward: {
     start: ["reward_start_date", "reward_announcement_start", "reward_start_at"],
     end: ["reward_end_date", "reward_announcement_end", "reward_end_at"],
-    id: ["reward_announcement", "reward_ann_id"],
+    id: ["reward_effective_announcement_id", "reward_announcement", "reward_ann_id"],
   },
   activity_support: {
     start: ["activity_support_start_date", "activity_support_announcement_start", "activity_support_start_at"],
     end: ["activity_support_end_date", "activity_support_announcement_end", "activity_support_end_at"],
-    id: ["activity_support_announcement", "activity_support_ann_id"],
+    id: ["activity_support_effective_announcement_id", "activity_support_announcement", "activity_support_ann_id"],
   },
   conference: {
     start: ["conference_start_date", "conference_announcement_start", "conference_start_at"],
     end: ["conference_end_date", "conference_announcement_end", "conference_end_at"],
-    id: ["conference_announcement", "conference_ann_id"],
+    id: ["conference_effective_announcement_id", "conference_announcement", "conference_ann_id"],
   },
   service: {
     start: ["service_start_date", "service_announcement_start", "service_start_at"],
     end: ["service_end_date", "service_announcement_end", "service_end_at"],
-    id: ["service_announcement", "service_ann_id"],
+    id: ["service_effective_announcement_id", "service_announcement", "service_ann_id"],
   },
 };
 
@@ -152,9 +152,8 @@ export const systemConfigAPI = {
     for (const slot of Object.keys(SLOT_TIME_KEYS)) {
       const startVal = pickFirst(root, SLOT_TIME_KEYS[slot].start);
       const endVal = pickFirst(root, SLOT_TIME_KEYS[slot].end);
-      const idVal =
-        normalized[slot === "main" ? "main_annoucement" : `${slot}_announcement`] ??
-        pickFirst(root, SLOT_TIME_KEYS[slot].id);
+      const legacyId = normalized[slot === "main" ? "main_annoucement" : `${slot}_announcement`];
+      const idVal = pickFirst(root, SLOT_TIME_KEYS[slot].id) ?? legacyId;
 
       const startISO = toISOorNull(startVal);
       const endISO = toISOorNull(endVal);

--- a/frontend_project_fund/app/member/components/announcements/AnnouncementPage.js
+++ b/frontend_project_fund/app/member/components/announcements/AnnouncementPage.js
@@ -183,6 +183,7 @@ export default function AnnouncementPage() {
   const [installmentPeriods, setInstallmentPeriods] = useState([]);
   const [systemNow, setSystemNow] = useState(null);
   const [loadingInstallments, setLoadingInstallments] = useState(true);
+  const [loadingSystemConfig, setLoadingSystemConfig] = useState(true);
 
   useEffect(() => {
     loadAnnouncements();
@@ -289,6 +290,7 @@ export default function AnnouncementPage() {
 
   const loadSystemConfig = async () => {
     try {
+      setLoadingSystemConfig(true);
       const rawConfig = await systemConfigAPI.getWindow();
       const normalized = systemConfigAPI.normalizeWindow(rawConfig);
 
@@ -344,8 +346,14 @@ export default function AnnouncementPage() {
       console.error("Error loading system config:", error);
       setSystemConfigAnnouncementIds([]);
       setSystemNow(null);
+    } finally {
+      setLoadingSystemConfig(false);
     }
   };
+
+  const isLoadingAnnouncementTable =
+    loadingAnnouncements ||
+    (announcementVisibilityFilter === "current" && loadingSystemConfig);
 
   const loadYears = async () => {
     setYearsLoading(true);
@@ -1112,7 +1120,7 @@ export default function AnnouncementPage() {
               )}
             </div>
 
-            {loadingAnnouncements ? (
+            {isLoadingAnnouncementTable ? (
               <div className="flex items-center justify-center py-8">
                 <div className="w-8 h-8 border-4 border-blue-200 border-t-blue-600 rounded-full animate-spin"></div>
                 <span className="ml-2 text-gray-600">กำลังโหลด...</span>


### PR DESCRIPTION
### Motivation
- Backend now supplies new `*_effective_announcement_id` keys for slot announcements, so the client should prefer those when normalizing system-config windows while remaining compatible with legacy keys.

### Description
- Added `*_effective_announcement_id` to the `id` key lists in `SLOT_TIME_KEYS` for all slots so `pickFirst` can pick the new keys. 
- Changed id resolution to prefer values from `SLOT_TIME_KEYS[slot].id` and fall back to the legacy normalized announcement fields (`main_annoucement` / `${slot}_announcement`).
- Added a trailing newline at end of file.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adac305a7c832b8e72d52b91d9a507)